### PR TITLE
Adding OVHcloud & Ubuntu machine deployment guides

### DIFF
--- a/content/deployment/deploy-digitalocean.md
+++ b/content/deployment/deploy-digitalocean.md
@@ -46,7 +46,7 @@ You must therefore generate (or bring) your own SSL certificate.
 
 > **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay droplet, run `cd openreplay/scripts/helmcharts && bash certmanager.sh` and follow the steps.
 
-1. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
+3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
    
 ```yaml
 ingress-nginx: &ingress-nginx

--- a/content/deployment/deploy-gcp.md
+++ b/content/deployment/deploy-gcp.md
@@ -68,7 +68,7 @@ Alternatively to creating a load balancer, you can bring (or generate) your own 
 
 > **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay instance, run `cd openreplay/scripts/helmcharts && bash certmanager.sh` and follow the steps.
 
-1. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
+3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
    
 ```yaml
 ingress-nginx: &ingress-nginx

--- a/content/deployment/deploy-kubernetes.md
+++ b/content/deployment/deploy-kubernetes.md
@@ -70,7 +70,7 @@ Alternatively to creating a load balancer, you can bring (or generate) your own 
 
 > **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay instance, run `cd openreplay/scripts/helmcharts && bash certmanager.sh` and follow the steps.
 
-1. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
+3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
    
 ```yaml
 ingress-nginx: &ingress-nginx

--- a/content/deployment/deploy-ovhcloud.md
+++ b/content/deployment/deploy-ovhcloud.md
@@ -1,0 +1,68 @@
+---
+title: "Deploy to OVHcloud"
+metaTitle: "Deploy to OVHcloud"
+metaDescription: "Step-by-step guide for deploying OpenReplay on OVHcloud (Dedicated server, VPS, Private Cloud virtual machine or Public Cloud instance)."
+---
+
+OpenReplay stack can be installed on a single machine and OVHcloud Dedicated server, VPS, Private Cloud virtual machine or Public Cloud instance is an ideal candidate. Here's how to do it.
+
+## Order your server or launch your instance
+
+You can use any of the following OVHcloud products to deploy OpenReplay:
+
+- Dedicated server
+- VPS
+- Private Cloud (inside a virtual machine)
+- Public Cloud instance
+
+Pre-requisites:
+
+- Pick *Ubuntu Server 20.04 Focal Fossa* as the operating system.
+- The minimum specs for the machine running OpenReplay are `2 vCPUs, 8 GB of RAM, 50 GB of storage`, otherwise OpenReplay backend services won't simply start. This should be enough for a low/moderate volume. If you're expecting high traffic, you should scale from here.
+- A public IP address pointing to your server/instance.
+
+## Deploy OpenReplay
+
+1. Make sure your server/instance is started then connect to it through SSH as root
+
+2. Install OpenReplay by providing the domain on which it will be running (e.g. DOMAIN_NAME=openreplay.mycompany.com):
+
+```bash
+git clone https://github.com/openreplay/openreplay.git
+cd openreplay/scripts/helmcharts
+DOMAIN_NAME=openreplay.mycompany.com bash init.sh
+```
+
+## Configure TLS/SSL
+
+OpenReplay deals with sensitive user data and therefore requires HTTPS to run. This is mandatory, otherwise the tracker simply wouldn't start recording. Same thing for the dashboard, without HTTPS you won't be able to replay user sessions.
+
+You must therefore bring (or generate) your own SSL certificate.
+
+1. First, go to your OVHcloud control panel in 'Web cloud' > 'Domain names' > your domain (i.e. mycompany.com) > 'DNS zone' (or your other DNS service provider) and create an `A Record`. Use the domain you previously provided during the installation step and point it to the server/instance using its public IP.
+
+2. If you're bringing your own certificate, create an SSL secret using the following command: `kubectl create secret tls openreplay-ssl -n app --key="private_key_file.pem" --cert="certificate.crt`.
+
+> **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay server/instance, run `bash openreplay/scripts/helmcharts/certmanager.sh` and follow the steps.
+
+3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
+   
+```yaml
+ingress-nginx: &ingress-nginx
+  controller:
+    config:
+      ssl-redirect: true
+      force-ssl-redirect: true
+```
+
+4. Finally reinstall OpenReplay NGINX:
+
+```bash
+cd openreplay/scripts/helmcharts && ./openreplay-cli -I
+```
+
+You're all set now, OpenReplay should be accessible on your subdomain. You can create an account by visiting the `/signup` page (i.e. openreplay.mycompany.com/signup).
+
+## Troubleshooting
+
+If you encounter any issues, connect to our [Discord](https://discord.openreplay.com) and get help from our community.

--- a/content/deployment/deploy-ovhcloud.md
+++ b/content/deployment/deploy-ovhcloud.md
@@ -43,7 +43,7 @@ You must therefore bring (or generate) your own SSL certificate.
 
 2. If you're bringing your own certificate, create an SSL secret using the following command: `kubectl create secret tls openreplay-ssl -n app --key="private_key_file.pem" --cert="certificate.crt`.
 
-> **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay server/instance, run `bash openreplay/scripts/helmcharts/certmanager.sh` and follow the steps.
+> **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay server/instance, run `cd openreplay/scripts/helmcharts && bash certmanager.sh` and follow the steps.
 
 3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
    

--- a/content/deployment/deploy-scaleway.md
+++ b/content/deployment/deploy-scaleway.md
@@ -52,7 +52,7 @@ You must therefore bring (or generate) your own SSL certificate.
 
 > **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay instance, run `cd openreplay/scripts/helmcharts && bash certmanager.sh` and follow the steps.
 
-1. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
+3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
    
 ```yaml
 ingress-nginx: &ingress-nginx

--- a/content/deployment/deploy-ubuntu.md
+++ b/content/deployment/deploy-ubuntu.md
@@ -1,0 +1,59 @@
+---
+title: "Deploy to Ubuntu"
+metaTitle: "Deploy to Ubuntu"
+metaDescription: "Step-by-step guide for deploying OpenReplay on any Ubuntu machine."
+---
+
+OpenReplay stack can be installed on a single machine running Ubuntu. Here's how to do it.
+
+## Pre-requisites
+
+- Operating system must be *Ubuntu Server 20.04 Focal Fossa*.
+- The minimum specs for the machine running OpenReplay are `2 vCPUs, 8 GB of RAM, 50 GB of storage`, otherwise OpenReplay backend services won't simply start. This should be enough for a low/moderate volume. If you're expecting high traffic, you should scale from here.
+- A public IP address pointing to your machine.
+
+## Deploy OpenReplay
+
+1. Make sure your machine is started then connect to it through SSH as root
+
+2. Install OpenReplay by providing the domain on which it will be running (e.g. DOMAIN_NAME=openreplay.mycompany.com):
+
+```bash
+git clone https://github.com/openreplay/openreplay.git
+cd openreplay/scripts/helmcharts
+DOMAIN_NAME=openreplay.mycompany.com bash init.sh
+```
+
+## Configure TLS/SSL
+
+OpenReplay deals with sensitive user data and therefore requires HTTPS to run. This is mandatory, otherwise the tracker simply wouldn't start recording. Same thing for the dashboard, without HTTPS you won't be able to replay user sessions.
+
+You must therefore bring (or generate) your own SSL certificate.
+
+1. First, go to your DNS service provider, edit your DNS zone and create an `A Record`. Use the domain you previously provided during the installation step and point it to the machine using its public IP.
+
+2. If you're bringing your own certificate, create an SSL secret using the following command: `kubectl create secret tls openreplay-ssl -n app --key="private_key_file.pem" --cert="certificate.crt`.
+
+> **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay machine, run `bash openreplay/scripts/helmcharts/certmanager.sh` and follow the steps.
+
+3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
+   
+```yaml
+ingress-nginx: &ingress-nginx
+  controller:
+    config:
+      ssl-redirect: true
+      force-ssl-redirect: true
+```
+
+4. Finally reinstall OpenReplay NGINX:
+
+```bash
+cd openreplay/scripts/helmcharts && ./openreplay-cli -I
+```
+
+You're all set now, OpenReplay should be accessible on your subdomain. You can create an account by visiting the `/signup` page (i.e. openreplay.mycompany.com/signup).
+
+## Troubleshooting
+
+If you encounter any issues, connect to our [Discord](https://discord.openreplay.com) and get help from our community.

--- a/content/deployment/deploy-ubuntu.md
+++ b/content/deployment/deploy-ubuntu.md
@@ -34,7 +34,7 @@ You must therefore bring (or generate) your own SSL certificate.
 
 2. If you're bringing your own certificate, create an SSL secret using the following command: `kubectl create secret tls openreplay-ssl -n app --key="private_key_file.pem" --cert="certificate.crt`.
 
-> **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay machine, run `bash openreplay/scripts/helmcharts/certmanager.sh` and follow the steps.
+> **Note:** If you don't have a certificate, generate one, that auto-renews, for your subdomain (the one provided during installation) using Let's Encrypt. Simply connect to OpenReplay machine, run `cd openreplay/scripts/helmcharts && bash certmanager.sh` and follow the steps.
 
 3. If you wish to enable http to https redirection (recommended), then uncomment the below block, under the `ingress-nginx` section, in `openreplay/scripts/helmcharts/vars.yaml`:
    

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,3 @@
-const { CACHING_PARAMS } = require("gatsby-plugin-s3/constants");
 require("dotenv").config();
 const queries = require("./src/utils/algolia");
 const config = require("./config");
@@ -47,20 +46,6 @@ const plugins = [
       head: true,
       // enable ip anonymization
       anonymize: true,
-    },
-  },
-  {
-    resolve: `gatsby-plugin-s3`,
-    options: {
-      bucketName: process.env.AWS_S3_BUCKET_NAME,
-      region: 'eu-central-1',
-      removeNonexistentObjects: false,
-      params: {
-        ...CACHING_PARAMS,
-        'media/**': {
-          CacheControl: 'public, max-age=31536000, immutable',
-        },
-      }
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "license": "MIT",
   "main": "n/a",
   "scripts": {
-    "dev": "gatsby develop",
+    "dev": "gatsby develop --prefix-paths",
     "build": "gatsby build --prefix-paths",
     "upload": "gatsby-plugin-s3 deploy --yes && node invalidate.js",
     "update": "git pull && npm i",


### PR DESCRIPTION
I added a documentation to use any OVHcloud product that would support single-machine deployment.
Also, as that's applicable to any Ubuntu machine hosted anywhere (with a few pre-requisites), I added a generic Ubuntu guide.