### PR TITLE
Fix typo on Network Options documentation

### DIFF
--- a/src/pages/en/installation/network-options.mdx
+++ b/src/pages/en/installation/network-options.mdx
@@ -3,7 +3,7 @@ title: "Network options"
 metaTitle: "Network options"
 metaDescription: "Network options plugin for OpenReplay."
 ---
-This page describes the `network` namespace of the OpenRplay javascript SDK [options](/sdk/constructor). It relates to capturing network requests such as `fetch` and `XHR`, including payloads if necesssary, and inspect them later on while replaying session recordings. This is very useful for understanding and fixing issues.
+This page describes the `network` namespace of the OpenReplay javascript SDK [options](/sdk/constructor). It relates to capturing network requests such as `fetch` and `XHR`, including payloads if necesssary, and inspect them later on while replaying session recordings. This is very useful for understanding and fixing issues.
 
 ## Network Options
 


### PR DESCRIPTION
This PR fixes a typo on the Network options documentation 
`OpenRplay` > `OpenReplay`