### PR TITLE
fix(docs): apollo graphql.mdx snippet syntax error

### DIFF
--- a/src/pages/en/plugins/graphql.mdx
+++ b/src/pages/en/plugins/graphql.mdx
@@ -95,7 +95,7 @@ import { ApolloLink } from '@apollo/client';
 import { recordGraphQL } from './openreplay'; // see above for recordGraphQL definition
 
 const trackerApolloLink = new ApolloLink((operation, forward) => {
-  return forward(operation).map(result) => {
+  return forward(operation).map((result) => {
     const operationDefinition = operation.query.definitions[0];
     return recordGraphQL(
       operationDefinition.kind === 'OperationDefinition' ? operationDefinition.operation : 'unknown?',


### PR DESCRIPTION
Fixed missing paren in snippet