### PR TITLE
Update patch-network.mdx - fix bad example of patchNetwork

### DIFF
--- a/src/pages/en/rn-sdk/patch-network.mdx
+++ b/src/pages/en/rn-sdk/patch-network.mdx
@@ -11,7 +11,7 @@ This method patches XHR and Fetch apis to intercept network requests.
 ```js
 import OR from '@openreplay/react-native'
 
-OR.tracker.patchNetwork(
+OR.patchNetwork(
     global,
 		(url) => url.includes('openreplaydomain'),
     { mode: 'fetch' }


### PR DESCRIPTION
patchNetwork is not on the ORTrackerConnector but instead on the OR object.