### PR TITLE
fix: correct typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
   </a>
 </p>
 
-OpenReplay is an open-source session replay stack that let's you see what users do on your web app, helping you troubleshoot issues faster.
+OpenReplay is an open-source session replay stack that lets you see what users do on your web app, helping you troubleshoot issues faster.
 
 ## Getting Started
 - [Deployment](https://docs.openreplay.com/deployment): OpenReplay can be deployed anywhere. Follow our step-by-step guides for deploying it on major public clouds and platforms.
-- [Installation](https://docs.openreplay.com/installation/setup-or): Setup OpenReplay in minutes and start recording user sessions.
+- [Installation](https://docs.openreplay.com/installation/setup-or): Set up OpenReplay in minutes and start recording user sessions.
 - [Configuration](https://docs.openreplay.com/configuration.md): Configure and secure your OpenReplay instance.
 
 ## Go Further
@@ -22,7 +22,7 @@ OpenReplay is an open-source session replay stack that let's you see what users 
 All MDX pages must go inside the `src/pages` folder, and in there, use the folder structure to determine where to add them. 
 
 ### Handling multiple versions of the same page
-Inside the `src/pages` folder you'll find language folders and version folders inside them. The version folders start with `vX.Y.Z`, those folder will have a copy of the root of the `src/pages` folder (minus themselves, of course).
+Inside the `src/pages` folder you'll find language folders and version folders inside them. The version folders start with `vX.Y.Z`; those folders will have a copy of the root of the `src/pages` folder (minus themselves, of course).
 
 For every new page that is added, it needs to be duplicated into every version folder to make sure the user is able to switch versions with the version navigation dropdown and still land on the desired page.
 

--- a/src/pages/en/structure/exported-data.mdx
+++ b/src/pages/en/structure/exported-data.mdx
@@ -140,7 +140,7 @@ mobile_viewcomponentevent_screen_name|text|behavioral|Mobile screen name
 mobile_viewcomponentevent_view_name|text|behavioral|Mobile view name
 mobile_viewcomponentevent_visible|boolean|behavioral|Is visible
 mobile_viewcomponentevent_timestamp|biginteger|behavioral|Mobile screen/view event timestamp
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 
 ## Have questions?
 If you have any questions about this process, feel free to reach out to us on our [Slack](https://slack.openreplay.com) or check out our [Forum](https://forum.openreplay.com).

--- a/src/pages/en/v1.11.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.11.0/structure/exported-data.mdx
@@ -81,7 +81,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 
@@ -169,7 +169,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 ## Have questions?

--- a/src/pages/en/v1.12.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.12.0/structure/exported-data.mdx
@@ -81,7 +81,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 
@@ -169,7 +169,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 ## Have questions?

--- a/src/pages/en/v1.13.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.13.0/structure/exported-data.mdx
@@ -81,7 +81,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 
@@ -169,7 +169,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 ## Have questions?

--- a/src/pages/en/v1.14.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.14.0/structure/exported-data.mdx
@@ -81,7 +81,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 
@@ -169,7 +169,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 ## Have questions?

--- a/src/pages/en/v1.15.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.15.0/structure/exported-data.mdx
@@ -81,7 +81,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 
@@ -169,7 +169,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 ## Have questions?

--- a/src/pages/en/v1.16.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.16.0/structure/exported-data.mdx
@@ -81,7 +81,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 
@@ -169,7 +169,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 ## Have questions?

--- a/src/pages/en/v1.17.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.17.0/structure/exported-data.mdx
@@ -81,7 +81,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 
@@ -169,7 +169,7 @@ issueevent_context|text|behavioral and technical|Relevant information on the iss
 issueevent_payload|text|behavioral and technical|Payload
 customissue_name|text|technical|Custom issue name
 customissue_payload|text|technical|Custom issue payload
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 batch_order_number|biginteger|technical|Order number in a batch. To reconstruct the order of messages, sort by received_at and batch_order_number
 
 ## Have questions?

--- a/src/pages/en/v1.18.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.18.0/structure/exported-data.mdx
@@ -141,7 +141,7 @@ mobile_viewcomponentevent_screen_name|text|behavioral|Mobile screen name
 mobile_viewcomponentevent_view_name|text|behavioral|Mobile view name
 mobile_viewcomponentevent_visible|boolean|behavioral|Is visible
 mobile_viewcomponentevent_timestamp|biginteger|behavioral|Mobile screen/view event timestamp
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 
 ## Have questions?
 If you have any questions about this process, feel free to reach out to us on our [Slack](https://slack.openreplay.com) or check out our [Forum](https://forum.openreplay.com).

--- a/src/pages/en/v1.19.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.19.0/structure/exported-data.mdx
@@ -141,7 +141,7 @@ mobile_viewcomponentevent_screen_name|text|behavioral|Mobile screen name
 mobile_viewcomponentevent_view_name|text|behavioral|Mobile view name
 mobile_viewcomponentevent_visible|boolean|behavioral|Is visible
 mobile_viewcomponentevent_timestamp|biginteger|behavioral|Mobile screen/view event timestamp
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 
 ## Have questions?
 If you have any questions about this process, feel free to reach out to us on our [Slack](https://slack.openreplay.com) or check out our [Forum](https://forum.openreplay.com).

--- a/src/pages/en/v1.20.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.20.0/structure/exported-data.mdx
@@ -141,7 +141,7 @@ mobile_viewcomponentevent_screen_name|text|behavioral|Mobile screen name
 mobile_viewcomponentevent_view_name|text|behavioral|Mobile view name
 mobile_viewcomponentevent_visible|boolean|behavioral|Is visible
 mobile_viewcomponentevent_timestamp|biginteger|behavioral|Mobile screen/view event timestamp
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 
 ## Have questions?
 If you have any questions about this process, feel free to reach out to us on our [Slack](https://slack.openreplay.com) or check out our [Forum](https://forum.openreplay.com).

--- a/src/pages/en/v1.21.0/structure/exported-data.mdx
+++ b/src/pages/en/v1.21.0/structure/exported-data.mdx
@@ -141,7 +141,7 @@ mobile_viewcomponentevent_screen_name|text|behavioral|Mobile screen name
 mobile_viewcomponentevent_view_name|text|behavioral|Mobile view name
 mobile_viewcomponentevent_visible|boolean|behavioral|Is visible
 mobile_viewcomponentevent_timestamp|biginteger|behavioral|Mobile screen/view event timestamp
-received_at|biginteger|technical|Timestamp when the event is recieved by connector
+received_at|biginteger|technical|Timestamp when the event is received by connector
 
 ## Have questions?
 If you have any questions about this process, feel free to reach out to us on our [Slack](https://slack.openreplay.com) or check out our [Forum](https://forum.openreplay.com).


### PR DESCRIPTION
## Summary
- fix grammar in README
- correct misspelling of "received" in exported-data docs

## Testing
- `pnpm lint:eslint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_b_68af267a717483329cb7e712edbd772b