### PR TITLE
Deploy: --size-only S3 sync to cut the upload step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     - run: npm ci
     - run: npm run build
     # Safety net for the --delete sync below: refuse to deploy a truncated build (which
-    # would wipe live pages from S3). The site emits ~13k HTML files; abort well below that.
+    # would wipe live pages from S3). The site emits ~15k HTML files; abort well below that.
     # Re-tune this floor if the page count ever legitimately drops (e.g. freezing old versions).
     - name: Guard against truncated build
       run: |
@@ -50,8 +50,11 @@ jobs:
           echo "::error::Build looks truncated ($count HTML files < 5000); aborting before --delete sync."
           exit 1
         fi
-    # --delete keeps the bucket in exact sync with the build output, so pages removed
-    # from source (e.g. retired pre-v1.17.0 versions) are also removed from S3.
-    - run: aws s3 sync ./dist/ s3://openreplay-documentation --acl public-read --exact-timestamps --delete
+    # --size-only: a fresh CI build rewrites every file's mtime, so the default mtime comparison
+    # re-uploads all ~15k objects every deploy. Comparing by size instead uploads only files whose
+    # byte size actually changed. Caveat: a same-length edit (e.g. a typo fix that keeps the length)
+    # won't be re-uploaded — trigger a one-off full deploy if that ever bites. (--size-only ignores
+    # timestamps, so --exact-timestamps is dropped.) --delete still prunes objects no longer built.
+    - run: aws s3 sync ./dist/ s3://openreplay-documentation --acl public-read --delete --size-only
     - run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID}} --paths "/*"
 


### PR DESCRIPTION
## Why

After the build step dropped ~50% (#262), the **S3 sync is now the dominant cost** — ~8–10 min every deploy. The reason: each CI run does a fresh checkout + `npm run build`, so all **~14,885 output files** get a new mtime, and `aws s3 sync`'s default mtime comparison re-uploads the *entire* site every deploy regardless of what actually changed.

## Change

One line in `.github/workflows/deploy.yml`:

```diff
- aws s3 sync ./dist/ s3://openreplay-documentation --acl public-read --exact-timestamps --delete
+ aws s3 sync ./dist/ s3://openreplay-documentation --acl public-read --delete --size-only
```

`--size-only` compares by byte size instead of mtime, so only files whose size actually changed are uploaded. On a normal docs edit that's a handful of files instead of ~15k — the sync should drop from ~8–10 min to seconds/low minutes. `--exact-timestamps` is dropped (it's a no-op once size-only is set); `--delete` stays so retired pages are still pruned.

## Caveat

`--size-only` can miss an edit that keeps the **exact same byte length** (e.g. a transposition typo fix like `teh`→`the`). Content edits almost always change length, and hashed `_astro/*` assets always get new filenames, so in practice this is low-risk for docs. If a stale page is ever observed, a one-off full re-deploy fixes it.

## Note

The bigger lever for both build *and* sync remains freezing the immutable old versions (v1.17–v1.25) — that cuts the **file count** (~15k → ~3k), which `--size-only` doesn't. This PR is the cheap, immediate win for the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)