### PR TITLE
CI: build on ubuntu-latest-l with a 30 GB heap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-l
 
     steps:
     - uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": " NODE_OPTIONS=--max_old_space_size=14000 astro build",
+    "build": " NODE_OPTIONS=--max_old_space_size=30000 astro build",
     "postbuild": "node scripts/prepare-index.js && node scripts/index-to-algolia.cjs && node scripts/format-sitemap.mjs",
     "preview": "astro preview",
     "format": "pnpm run format:code",


### PR DESCRIPTION
## Summary

The deploy build on `main` is failing with **`JavaScript heap out of memory`** (exit 134). After the image-resolution fix (#266) let the build run to completion, the fully-translated site — ~12,700 pages across 6 languages — exhausts the build heap on the default `ubuntu-latest` runner.

## Changes
- **`deploy.yml`**: `runs-on: ubuntu-latest` → **`ubuntu-latest-l`** (larger runner, more RAM/CPU).
- **`package.json`**: build heap `--max_old_space_size=14000` → **`30000`** (30 GB).

## Notes
- This assumes `ubuntu-latest-l` has comfortably more than 30 GB RAM (so the 30 GB V8 heap fits alongside OS/Node overhead).
- `build.concurrency` is left at 4. If the build still OOMs on the larger runner, the next lever is lowering `build.concurrency` in `astro.config.ts` (fewer pages rendered in parallel → lower peak memory), at the cost of build speed.
- Validated by the CI deploy run on merge (this config can't be reproduced on a 16 GB dev machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
