### PR TITLE
i18n: translate the left nav menu centrally (all languages + versions)

### DIFF
--- a/src/i18n/ar-ae/ui.ts
+++ b/src/i18n/ar-ae/ui.ts
@@ -1,3 +1,19 @@
 import { UIDictionary } from '../translation-checkers';
 
-export default UIDictionary({});
+export default UIDictionary({
+	'leftSidebar.a11yTitle': 'التنقل الرئيسي',
+	'leftSidebar.learnTab': 'التعلّم',
+	'leftSidebar.referenceTab': 'المرجع',
+	'leftSidebar.viewInEnglish': 'العرض بالإنجليزية',
+	'leftSidebar.sponsoredBy': 'برعاية',
+	'rightSidebar.a11yTitle': 'التنقل الثانوي',
+	'rightSidebar.onThisPage': 'في هذه الصفحة',
+	'rightSidebar.overview': 'نظرة عامة',
+	'rightSidebar.community': 'المجتمع',
+	'rightSidebar.joinSlack': 'انضم إلى مجتمع Slack',
+	'rightSidebar.readBlog': 'المدونة',
+	'rightSidebar.contribute': 'ساهم',
+	'rightSidebar.editPage': 'تعديل هذه الصفحة',
+	'rightSidebar.translatePage': 'ترجمة هذه الصفحة',
+	'rightSidebar.github': 'تصفّح GitHub',
+});

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -1,5 +1,9 @@
+export type LocalizedText =
+  | string
+  | { en: string; fr?: string; es?: string; ru?: string; zh?: string; 'ar-ae'?: string }
+
 export interface NavItem {
-  text: string
+  text: LocalizedText
   slug: string | null
   icon?: string
   hideChevron?: boolean
@@ -12,7 +16,7 @@ const nav: NavItem = {
   slug: '',
   children: [
     {
-      text: 'Intro',
+      text: { en: 'Intro', fr: 'Introduction', es: 'Introducción', ru: 'Введение', zh: '简介', 'ar-ae': 'مقدمة' },
       slug: null,
       icon: 'home',
       hideChevron: true,
@@ -20,14 +24,14 @@ const nav: NavItem = {
       isSectionTitle: true
     },
     {
-      text: 'Home',
+      text: { en: 'Home', fr: 'Accueil', es: 'Inicio', ru: 'Главная', zh: '首页', 'ar-ae': 'الرئيسية' },
       slug: 'home',
       icon: 'home',
       hideChevron: true,
       children: []
     },
     {
-      text: 'Getting started',
+      text: { en: 'Getting started', fr: 'Démarrage rapide', es: 'Primeros pasos', ru: 'Начало работы', zh: '快速入门', 'ar-ae': 'البدء السريع' },
       slug: 'getting-started',
       icon: 'start',
       hideChevron: true,
@@ -38,7 +42,7 @@ const nav: NavItem = {
       ]
     },
     {
-      text: 'Deployment',
+      text: { en: 'Deployment', fr: 'Déploiement', es: 'Despliegue', ru: 'Развёртывание', zh: '部署', 'ar-ae': 'النشر' },
       slug: null,
       icon: 'null',
       hideChevron: true,
@@ -46,12 +50,12 @@ const nav: NavItem = {
       isSectionTitle: true
     },
     {
-      text: 'Deployment',
+      text: { en: 'Deployment', fr: 'Déploiement', es: 'Despliegue', ru: 'Развёртывание', zh: '部署', 'ar-ae': 'النشر' },
       slug: 'deployment/',
       icon: 'deployment',
       children: [
-        { text: 'Overview', slug: 'deployment/', children: [] },
-        { text: 'Cloud Providers', slug: null, children: [
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'deployment/', children: [] },
+        { text: { en: 'Cloud Providers', fr: 'Fournisseurs cloud', es: 'Proveedores en la nube', ru: 'Облачные провайдеры', zh: '云服务商', 'ar-ae': 'موفرو السحابة' }, slug: null, children: [
           { text: 'Deploy to AWS', slug: 'deployment/deploy-aws', children: [] },
           { text: 'Deploy to Azure', slug: 'deployment/deploy-azure', children: [] },
           { text: 'Deploy to GCP', slug: 'deployment/deploy-gcp', children: [] },
@@ -59,40 +63,40 @@ const nav: NavItem = {
           { text: 'Deploy to OVHCloud', slug: 'deployment/deploy-ovhcloud', children: [] },
           { text: 'Deploy to Scaleway', slug: 'deployment/deploy-scaleway', children: [] }
         ] },
-        { text: 'Self-Hosting', slug: null, children: [
+        { text: { en: 'Self-Hosting', fr: 'Auto-hébergement', es: 'Autoalojamiento', ru: 'Самостоятельный хостинг', zh: '自托管', 'ar-ae': 'الاستضافة الذاتية' }, slug: null, children: [
           { text: 'Deploy to Kubernetes', slug: 'deployment/deploy-kubernetes', children: [] },
           { text: 'Deploy to Docker', slug: 'deployment/deploy-docker', children: [] },
           { text: 'Deploy to Ubuntu', slug: 'deployment/deploy-ubuntu', children: [] }
         ] },
-        { text: 'Deploy from Source', slug: 'deployment/deploy-source', children: [] },
-        { text: 'Maintenance', slug: null, children: [
+        { text: { en: 'Deploy from Source', fr: 'Déployer depuis la source', es: 'Desplegar desde el código fuente', ru: 'Развернуть из исходников', zh: '从源码部署', 'ar-ae': 'النشر من المصدر' }, slug: 'deployment/deploy-source', children: [] },
+        { text: { en: 'Maintenance', fr: 'Maintenance', es: 'Mantenimiento', ru: 'Обслуживание', zh: '维护', 'ar-ae': 'الصيانة' }, slug: null, children: [
           { text: 'OpenReplay CLI', slug: 'deployment/openreplay-admin', children: []},
-          { text: 'Upgrade Deployment', slug: 'deployment/upgrade', children: [] }
+          { text: { en: 'Upgrade Deployment', fr: 'Mise à jour du déploiement', es: 'Actualizar despliegue', ru: 'Обновление развёртывания', zh: '升级部署', 'ar-ae': 'ترقية النشر' }, slug: 'deployment/upgrade', children: [] }
         ] },
-        { text: 'Installation', slug: null, children: [
-          { text: 'Setup OpenReplay', slug: 'deployment/setup-or', children: [] },
-          { text: 'Upload Source Maps', slug: 'deployment/upload-sourcemaps', children: [] },
+        { text: { en: 'Installation', fr: 'Installation', es: 'Instalación', ru: 'Установка', zh: '安装', 'ar-ae': 'التثبيت' }, slug: null, children: [
+          { text: { en: 'Setup OpenReplay', fr: 'Installer OpenReplay', es: 'Configurar OpenReplay', ru: 'Настройка OpenReplay', zh: '配置 OpenReplay', 'ar-ae': 'إعداد OpenReplay' }, slug: 'deployment/setup-or', children: [] },
+          { text: { en: 'Upload Source Maps', fr: 'Téléverser les source maps', es: 'Subir source maps', ru: 'Загрузить source maps', zh: '上传 Source Maps', 'ar-ae': 'رفع خرائط المصدر' }, slug: 'deployment/upload-sourcemaps', children: [] },
         ] },
-        { text: 'Administration', slug: null, children: [
-          { text: 'Team Management', slug: 'deployment/invite-team-members', children: [] },
-          { text: 'Roles and Access', slug: 'deployment/roles-and-access', children: [] }
+        { text: { en: 'Administration', fr: 'Administration', es: 'Administración', ru: 'Администрирование', zh: '管理', 'ar-ae': 'الإدارة' }, slug: null, children: [
+          { text: { en: 'Team Management', fr: 'Gestion d\'équipe', es: 'Gestión de equipos', ru: 'Управление командой', zh: '团队管理', 'ar-ae': 'إدارة الفريق' }, slug: 'deployment/invite-team-members', children: [] },
+          { text: { en: 'Roles and Access', fr: 'Rôles et accès', es: 'Roles y acceso', ru: 'Роли и доступ', zh: '角色与权限', 'ar-ae': 'الأدوار والصلاحيات' }, slug: 'deployment/roles-and-access', children: [] }
         ] },
-        { text: 'Tracker Compatibility', slug: 'deployment/compatibility', children: [] },
+        { text: { en: 'Tracker Compatibility', fr: 'Compatibilité du tracker', es: 'Compatibilidad del tracker', ru: 'Совместимость трекера', zh: '追踪器兼容性', 'ar-ae': 'توافق المتتبع' }, slug: 'deployment/compatibility', children: [] },
         
       ]
     },
     {
-      text: 'Configuration',
+      text: { en: 'Configuration', fr: 'Configuration', es: 'Configuración', ru: 'Конфигурация', zh: '配置', 'ar-ae': 'الإعداد' },
       slug: 'configuration/',
       icon: 'configure',
       children: [
-        { text: 'Overview', slug: 'configuration', children: [] },
-        { text: 'Cleanup Storage', slug: 'configuration/cleanup-storage', children: [] },
-        { text: 'Configure SMTP', slug: 'configuration/configure-smtp', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'configuration', children: [] },
+        { text: { en: 'Cleanup Storage', fr: 'Nettoyer le stockage', es: 'Limpiar almacenamiento', ru: 'Очистка хранилища', zh: '清理存储', 'ar-ae': 'تنظيف التخزين' }, slug: 'configuration/cleanup-storage', children: [] },
+        { text: { en: 'Configure SMTP', fr: 'Configurer SMTP', es: 'Configurar SMTP', ru: 'Настройка SMTP', zh: '配置 SMTP', 'ar-ae': 'إعداد SMTP' }, slug: 'configuration/configure-smtp', children: [] },
         { text: 'External Database (Postgres)', slug: 'configuration/external-db', children: [] },
-        { text: 'External Storage', slug: 'configuration/external-storage', children: [] },
-        { text: 'Proxy Settings', slug: 'configuration/proxy-settings', children: [] },
-        { text: 'Secure OpenReplay', slug: 'configuration/secure-or', children: [] },
+        { text: { en: 'External Storage', fr: 'Stockage externe', es: 'Almacenamiento externo', ru: 'Внешнее хранилище', zh: '外部存储', 'ar-ae': 'التخزين الخارجي' }, slug: 'configuration/external-storage', children: [] },
+        { text: { en: 'Proxy Settings', fr: 'Paramètres proxy', es: 'Configuración de proxy', ru: 'Настройки прокси', zh: '代理设置', 'ar-ae': 'إعدادات الوكيل' }, slug: 'configuration/proxy-settings', children: [] },
+        { text: { en: 'Secure OpenReplay', fr: 'Sécuriser OpenReplay', es: 'Proteger OpenReplay', ru: 'Защита OpenReplay', zh: '安全配置', 'ar-ae': 'تأمين OpenReplay' }, slug: 'configuration/secure-or', children: [] },
         { text: 'Single Sign-On (SSO)', slug: 'configuration/sso', children: [] },
       ]
     },
@@ -109,9 +113,9 @@ const nav: NavItem = {
       slug: 'sdk',
       icon: 'sdk',
       children: [
-        { text: 'Overview', slug: 'sdk', children: [] },
-        { text: 'Initialization', slug: 'sdk/constructor', children: [] },
-        { text: 'Methods', slug: 'sdk/methods', children: [
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'sdk', children: [] },
+        { text: { en: 'Initialization', fr: 'Initialisation', es: 'Inicialización', ru: 'Инициализация', zh: '初始化', 'ar-ae': 'التهيئة' }, slug: 'sdk/constructor', children: [] },
+        { text: { en: 'Methods', fr: 'Méthodes', es: 'Métodos', ru: 'Методы', zh: '方法', 'ar-ae': 'الوظائف' }, slug: 'sdk/methods', children: [
           { text: 'event', slug: 'sdk/methods/event' },
           { text: 'getSessionToken', slug: 'sdk/methods/get-session-token', children: [] },
           { text: 'getSessionID', slug: 'sdk/methods/get-session-id', children: [] },
@@ -137,18 +141,18 @@ const nav: NavItem = {
           { text: 'trackWs', slug: 'sdk/methods/track-ws', children: [] }, 
           { text: 'incident', slug: 'sdk/methods/incident', children: [] },
         ] },
-        { text: 'Network Options', slug: 'sdk/network-options', children: [] },
+        { text: { en: 'Network Options', fr: 'Options réseau', es: 'Opciones de red', ru: 'Сетевые параметры', zh: '网络选项', 'ar-ae': 'خيارات الشبكة' }, slug: 'sdk/network-options', children: [] },
 				{
-					text: 'Analytics', slug: 'sdk/analytics', children: [
-						{ text: 'Overview', slug: 'sdk/analytics', children: [] },
-						{ text: 'People', slug: 'sdk/analytics/people', children: [] },
-						{ text: 'Events', slug: 'sdk/analytics/events', children: [] },
+					text: { en: 'Analytics', fr: 'Analytique', es: 'Analítica', ru: 'Аналитика', zh: '分析', 'ar-ae': 'التحليلات' }, slug: 'sdk/analytics', children: [
+						{ text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'sdk/analytics', children: [] },
+						{ text: { en: 'People', fr: 'Personnes', es: 'Personas', ru: 'Пользователи', zh: '成员', 'ar-ae': 'الأشخاص' }, slug: 'sdk/analytics/people', children: [] },
+						{ text: { en: 'Events', fr: 'Événements', es: 'Eventos', ru: 'События', zh: '事件', 'ar-ae': 'الأحداث' }, slug: 'sdk/analytics/events', children: [] },
 					]
 				},
-        { text: 'Sanitize Data', slug: 'sdk/sanitize-data', children: [] },
-        { text: 'Private Mode', slug: 'sdk/private-mode', children: [] },
-        { text: 'Frameworks', slug: 'sdk/using-or/', children: [
-          { text: 'Overview', slug: 'sdk/using-or/', children: [] },
+        { text: { en: 'Sanitize Data', fr: 'Nettoyer les données', es: 'Sanear datos', ru: 'Очистка данных', zh: '数据脱敏', 'ar-ae': 'تنقية البيانات' }, slug: 'sdk/sanitize-data', children: [] },
+        { text: { en: 'Private Mode', fr: 'Mode privé', es: 'Modo privado', ru: 'Приватный режим', zh: '隐私模式', 'ar-ae': 'الوضع الخاص' }, slug: 'sdk/private-mode', children: [] },
+        { text: { en: 'Frameworks', fr: 'Frameworks', es: 'Frameworks', ru: 'Фреймворки', zh: '框架', 'ar-ae': 'أطر العمل' }, slug: 'sdk/using-or/', children: [
+          { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'sdk/using-or/', children: [] },
           { text: 'React', slug: 'sdk/using-or/react', children: [] },
           { text: 'Vue', slug: 'sdk/using-or/vue', children: [] },
           { text: 'Next.js', slug: 'sdk/using-or/next', children: [] },
@@ -165,9 +169,9 @@ const nav: NavItem = {
       slug: 'ios-sdk',
       icon: 'ios_app',
       children: [
-        { text: 'Initialization', slug: 'ios-sdk/init', children: [] },
-        { text: 'Modules', slug: 'ios-sdk/modules', children: [] },
-        { text: 'Methods', slug: 'ios-sdk/methods', children: [
+        { text: { en: 'Initialization', fr: 'Initialisation', es: 'Inicialización', ru: 'Инициализация', zh: '初始化', 'ar-ae': 'التهيئة' }, slug: 'ios-sdk/init', children: [] },
+        { text: { en: 'Modules', fr: 'Modules', es: 'Módulos', ru: 'Модули', zh: '模块', 'ar-ae': 'الوحدات' }, slug: 'ios-sdk/modules', children: [] },
+        { text: { en: 'Methods', fr: 'Méthodes', es: 'Métodos', ru: 'Методы', zh: '方法', 'ar-ae': 'الوظائف' }, slug: 'ios-sdk/methods', children: [
           { text: 'event', slug: 'ios-sdk/methods/event' , children: []},
           { text: 'setUserID', slug: 'ios-sdk/methods/set-user-id', children: [] },
           { text: 'userAnonymousID', slug: 'ios-sdk/methods/user-anonymous-id', children: [] },
@@ -175,9 +179,9 @@ const nav: NavItem = {
           { text: 'start', slug: 'ios-sdk/methods/start', children: [] },
           { text: 'stop', slug: 'ios-sdk/methods/stop', children: [] },
         ] },
-        { text: 'Inputs', slug: 'ios-sdk/inputs', children: [] },     
-        { text: 'Network Options', slug: 'ios-sdk/network', children: [] },
-        { text: 'Sanitize Data', slug: 'ios-sdk/sanitization', children: [] },
+        { text: { en: 'Inputs', fr: 'Entrées', es: 'Entradas', ru: 'Входные данные', zh: '输入', 'ar-ae': 'المدخلات' }, slug: 'ios-sdk/inputs', children: [] },     
+        { text: { en: 'Network Options', fr: 'Options réseau', es: 'Opciones de red', ru: 'Сетевые параметры', zh: '网络选项', 'ar-ae': 'خيارات الشبكة' }, slug: 'ios-sdk/network', children: [] },
+        { text: { en: 'Sanitize Data', fr: 'Nettoyer les données', es: 'Sanear datos', ru: 'Очистка данных', zh: '数据脱敏', 'ar-ae': 'تنقية البيانات' }, slug: 'ios-sdk/sanitization', children: [] },
       ]
     },
     {
@@ -185,18 +189,18 @@ const nav: NavItem = {
       slug: 'android-sdk',
       icon: 'android_app',
       children: [
-        { text: 'Initialization', slug: 'android-sdk/init', children: [] },
-        { text: 'Modules', slug: 'android-sdk/modules', children: [] },
-        { text: 'Methods', slug: 'android-sdk/methods', children: [
+        { text: { en: 'Initialization', fr: 'Initialisation', es: 'Inicialización', ru: 'Инициализация', zh: '初始化', 'ar-ae': 'التهيئة' }, slug: 'android-sdk/init', children: [] },
+        { text: { en: 'Modules', fr: 'Modules', es: 'Módulos', ru: 'Модули', zh: '模块', 'ar-ae': 'الوحدات' }, slug: 'android-sdk/modules', children: [] },
+        { text: { en: 'Methods', fr: 'Méthodes', es: 'Métodos', ru: 'Методы', zh: '方法', 'ar-ae': 'الوظائف' }, slug: 'android-sdk/methods', children: [
           { text: 'event', slug: 'android-sdk/methods/event' , children: []},
           { text: 'setUserID', slug: 'android-sdk/methods/set-user-id', children: [] },
           { text: 'userAnonymousID', slug: 'android-sdk/methods/user-anonymous-id', children: [] },
           { text: 'setMetadata', slug: 'android-sdk/methods/set-metadata', children: [] },
           { text: 'start', slug: 'android-sdk/methods/start', children: [] },
         ] },
-        { text: 'Inputs', slug: 'android-sdk/inputs', children: [] },        
-        { text: 'Network Options', slug: 'android-sdk/network', children: [] },
-        { text: 'Sanitize Data', slug: 'android-sdk/sanitization', children: [] },
+        { text: { en: 'Inputs', fr: 'Entrées', es: 'Entradas', ru: 'Входные данные', zh: '输入', 'ar-ae': 'المدخلات' }, slug: 'android-sdk/inputs', children: [] },        
+        { text: { en: 'Network Options', fr: 'Options réseau', es: 'Opciones de red', ru: 'Сетевые параметры', zh: '网络选项', 'ar-ae': 'خيارات الشبكة' }, slug: 'android-sdk/network', children: [] },
+        { text: { en: 'Sanitize Data', fr: 'Nettoyer les données', es: 'Sanear datos', ru: 'Очистка данных', zh: '数据脱敏', 'ar-ae': 'تنقية البيانات' }, slug: 'android-sdk/sanitization', children: [] },
       ]
     },
     {
@@ -204,9 +208,9 @@ const nav: NavItem = {
       slug: 'rn-sdk',
       icon: 'react-native_ios_app',
       children: [
-        { text: 'Initialization', slug: 'rn-sdk/init', children: [] },
-        { text: 'Modules', slug: 'rn-sdk/modules', children: [] },
-        { text: 'Methods', slug: 'rn-sdk/methods', children: [
+        { text: { en: 'Initialization', fr: 'Initialisation', es: 'Inicialización', ru: 'Инициализация', zh: '初始化', 'ar-ae': 'التهيئة' }, slug: 'rn-sdk/init', children: [] },
+        { text: { en: 'Modules', fr: 'Modules', es: 'Módulos', ru: 'Модули', zh: '模块', 'ar-ae': 'الوحدات' }, slug: 'rn-sdk/modules', children: [] },
+        { text: { en: 'Methods', fr: 'Méthodes', es: 'Métodos', ru: 'Методы', zh: '方法', 'ar-ae': 'الوظائف' }, slug: 'rn-sdk/methods', children: [
           { text: 'event', slug: 'rn-sdk/methods/event' , children: []},
           { text: 'setUserID', slug: 'rn-sdk/methods/set-user-id', children: [] },
           { text: 'userAnonymousID', slug: 'rn-sdk/methods/user-anonymous-id', children: [] },
@@ -214,13 +218,13 @@ const nav: NavItem = {
           { text: 'start', slug: 'rn-sdk/methods/start', children: [] },
           { text: 'patchNetwork', slug: 'rn-sdk/methods/patch-network', children: [] },
         ] },
-        { text: 'Inputs', slug: 'rn-sdk/inputs', children: [] },        
-        { text: 'Network Options', slug: 'rn-sdk/network', children: [] },
-        { text: 'Sanitize Data', slug: 'rn-sdk/sanitization', children: [] },
+        { text: { en: 'Inputs', fr: 'Entrées', es: 'Entradas', ru: 'Входные данные', zh: '输入', 'ar-ae': 'المدخلات' }, slug: 'rn-sdk/inputs', children: [] },        
+        { text: { en: 'Network Options', fr: 'Options réseau', es: 'Opciones de red', ru: 'Сетевые параметры', zh: '网络选项', 'ar-ae': 'خيارات الشبكة' }, slug: 'rn-sdk/network', children: [] },
+        { text: { en: 'Sanitize Data', fr: 'Nettoyer les données', es: 'Sanear datos', ru: 'Очистка данных', zh: '数据脱敏', 'ar-ae': 'تنقية البيانات' }, slug: 'rn-sdk/sanitization', children: [] },
       ]
     },
     {
-      text: 'Products',
+      text: { en: 'Products', fr: 'Produits', es: 'Productos', ru: 'Продукты', zh: '产品', 'ar-ae': 'المنتجات' },
       slug: null,
       icon: 'null',
       hideChevron: true,
@@ -232,44 +236,44 @@ const nav: NavItem = {
       slug: 'session-replay',
       icon: 'session-replay',
       children: [
-        { text: 'Overview', slug: 'session-replay', children: [] },
-        { text: 'Guides', slug: null, children: [ 
-          { text: 'Omnisearch', slug: 'session-replay/omnisearch', children: [] },
-          { text: 'Segments', slug: 'session-replay/segments', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'session-replay', children: [] },
+        { text: { en: 'Guides', fr: 'Guides', es: 'Guías', ru: 'Руководства', zh: '指南', 'ar-ae': 'الأدلة' }, slug: null, children: [ 
+          { text: { en: 'Omnisearch', fr: 'Recherche universelle', es: 'Búsqueda global', ru: 'Универсальный поиск', zh: '全局搜索', 'ar-ae': 'البحث الشامل' }, slug: 'session-replay/omnisearch', children: [] },
+          { text: { en: 'Segments', fr: 'Segments', es: 'Segmentos', ru: 'Сегменты', zh: '细分群组', 'ar-ae': 'الشرائح' }, slug: 'session-replay/segments', children: [] },
           { text: 'Highlights', slug: 'session-replay/highlights', children: [] },
-          { text: 'Session to E2E Test', slug: 'session-replay/generate-e2e-test', children: [] },
+          { text: { en: 'Session to E2E Test', fr: 'Session vers test E2E', es: 'Sesión a prueba E2E', ru: 'Сессия в E2E-тест', zh: '会话转 E2E 测试', 'ar-ae': 'تحويل الجلسة إلى اختبار E2E' }, slug: 'session-replay/generate-e2e-test', children: [] },
         ] 
         },
-        { text: 'Advanced Setup', slug: null, children: [
-          { text: 'Identify a User', slug: 'session-replay/identify-user', children: [] },
-          { text: 'Send Metadata', slug: 'session-replay/metadata', children: [] },
+        { text: { en: 'Advanced Setup', fr: 'Configuration avancée', es: 'Configuración avanzada', ru: 'Расширенная настройка', zh: '高级配置', 'ar-ae': 'الإعداد المتقدم' }, slug: null, children: [
+          { text: { en: 'Identify a User', fr: 'Identifier un utilisateur', es: 'Identificar un usuario', ru: 'Идентификация пользователя', zh: '标识用户', 'ar-ae': 'تعريف المستخدم' }, slug: 'session-replay/identify-user', children: [] },
+          { text: { en: 'Send Metadata', fr: 'Envoyer des métadonnées', es: 'Enviar metadatos', ru: 'Отправить метаданные', zh: '发送元数据', 'ar-ae': 'إرسال البيانات الوصفية' }, slug: 'session-replay/metadata', children: [] },
           { text: 'Canvas and WebGL', slug: 'session-replay/canvas', children: [] },
           { text: 'Cross-domain iFrames', slug: 'session-replay/crossdomain-iframe', children: [] },
           { text: 'WebSockets', slug: 'session-replay/websockets', children: [] },
-          { text: 'Error Tracking', slug: 'session-replay/error-reporting', children: [] },
+          { text: { en: 'Error Tracking', fr: 'Suivi des erreurs', es: 'Seguimiento de errores', ru: 'Отслеживание ошибок', zh: '错误追踪', 'ar-ae': 'تتبع الأخطاء' }, slug: 'session-replay/error-reporting', children: [] },
         ] 
         },
       ]
     },
     {
-      text: 'Product Analytics',
+      text: { en: 'Product Analytics', fr: 'Analytique produit', es: 'Analítica de producto', ru: 'Продуктовая аналитика', zh: '产品分析', 'ar-ae': 'تحليلات المنتج' },
       slug: 'product-analytics',
       icon: 'product-analytics',
       children: [
-        { text: 'Overview', slug: 'product-analytics', children: [] },
-        { text: 'Guides', slug: null, children: [
-          { text: 'Trends', slug: 'product-analytics/trends', children: [] },
-          { text: 'Funnels', slug: 'product-analytics/funnels', children: [] },
-          { text: 'Journeys', slug: 'product-analytics/journeys', children: [] },
-          { text: 'Heatmaps', slug: 'product-analytics/heatmaps', children: [] },
-          { text: 'Dashboards', slug: 'product-analytics/dashboards', children: [] },
-          { text: 'Web Analytics', slug: 'product-analytics/web-analytics', children: [] },
-          { text: 'Monitors', slug: 'product-analytics/monitors', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'product-analytics', children: [] },
+        { text: { en: 'Guides', fr: 'Guides', es: 'Guías', ru: 'Руководства', zh: '指南', 'ar-ae': 'الأدلة' }, slug: null, children: [
+          { text: { en: 'Trends', fr: 'Tendances', es: 'Tendencias', ru: 'Тренды', zh: '趋势', 'ar-ae': 'الاتجاهات' }, slug: 'product-analytics/trends', children: [] },
+          { text: { en: 'Funnels', fr: 'Entonnoirs', es: 'Embudos', ru: 'Воронки', zh: '漏斗', 'ar-ae': 'مسارات التحويل' }, slug: 'product-analytics/funnels', children: [] },
+          { text: { en: 'Journeys', fr: 'Parcours', es: 'Recorridos', ru: 'Пути', zh: '用户旅程', 'ar-ae': 'مسارات المستخدم' }, slug: 'product-analytics/journeys', children: [] },
+          { text: { en: 'Heatmaps', fr: 'Cartes de chaleur', es: 'Mapas de calor', ru: 'Тепловые карты', zh: '热力图', 'ar-ae': 'الخرائط الحرارية' }, slug: 'product-analytics/heatmaps', children: [] },
+          { text: { en: 'Dashboards', fr: 'Tableaux de bord', es: 'Paneles', ru: 'Дашборды', zh: '仪表板', 'ar-ae': 'لوحات المعلومات' }, slug: 'product-analytics/dashboards', children: [] },
+          { text: { en: 'Web Analytics', fr: 'Analytique web', es: 'Analítica web', ru: 'Веб-аналитика', zh: '网页分析', 'ar-ae': 'تحليلات الويب' }, slug: 'product-analytics/web-analytics', children: [] },
+          { text: { en: 'Monitors', fr: 'Moniteurs', es: 'Monitores', ru: 'Мониторы', zh: '监控', 'ar-ae': 'أجهزة الرصد' }, slug: 'product-analytics/monitors', children: [] },
         ]
         },
-        { text: 'Advanced Setup', slug: null, children: [
-					{ text: 'Custom Events', slug: 'product-analytics/custom-events', children: [] },
-          { text: 'Data Management', slug: 'product-analytics/data-management', children: [] }
+        { text: { en: 'Advanced Setup', fr: 'Configuration avancée', es: 'Configuración avanzada', ru: 'Расширенная настройка', zh: '高级配置', 'ar-ae': 'الإعداد المتقدم' }, slug: null, children: [
+					{ text: { en: 'Custom Events', fr: 'Événements personnalisés', es: 'Eventos personalizados', ru: 'Пользовательские события', zh: '自定义事件', 'ar-ae': 'الأحداث المخصصة' }, slug: 'product-analytics/custom-events', children: [] },
+          { text: { en: 'Data Management', fr: 'Gestion des données', es: 'Gestión de datos', ru: 'Управление данными', zh: '数据管理', 'ar-ae': 'إدارة البيانات' }, slug: 'product-analytics/data-management', children: [] }
         ]
         },
       ]
@@ -278,7 +282,7 @@ const nav: NavItem = {
       text: 'Co-browsing', slug: 'co-browsing', icon: 'co-browsing', children: []
     },
     {
-      text: 'Platform',
+      text: { en: 'Platform', fr: 'Plateforme', es: 'Plataforma', ru: 'Платформа', zh: '平台', 'ar-ae': 'المنصة' },
       slug: null,
       icon: 'null',
       hideChevron: true,
@@ -290,10 +294,10 @@ const nav: NavItem = {
       slug: 'ai',
       icon: 'ai',
       children: [
-        { text: 'Overview', slug: 'ai', children: [] },
-        { text: 'Summary AI ', slug: 'ai/summary-ai', children: [] },
-        { text: 'Similar Sessions', slug: 'ai/similar-sessions', children: [] },
-        { text: 'Explain AI', slug: 'ai/explain-ai', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'ai', children: [] },
+        { text: { en: 'Summary AI', fr: 'Résumé par IA', es: 'Resumen con IA', ru: 'Сводка ИИ', zh: 'AI 摘要', 'ar-ae': 'ملخص بالذكاء الاصطناعي' }, slug: 'ai/summary-ai', children: [] },
+        { text: { en: 'Similar Sessions', fr: 'Sessions similaires', es: 'Sesiones similares', ru: 'Похожие сессии', zh: '相似会话', 'ar-ae': 'جلسات مشابهة' }, slug: 'ai/similar-sessions', children: [] },
+        { text: { en: 'Explain AI', fr: 'Expliquer par IA', es: 'Explicar con IA', ru: 'Объяснение ИИ', zh: 'AI 解释', 'ar-ae': 'شرح بالذكاء الاصطناعي' }, slug: 'ai/explain-ai', children: [] },
       ]
     },
     {
@@ -301,17 +305,17 @@ const nav: NavItem = {
       slug: 'mcp',
       icon: 'ai',
       children: [
-        { text: 'Overview', slug: 'mcp', children: [] },
-        { text: 'Setup', slug: 'mcp/setup', children: [] },
-        { text: 'Capabilities', slug: 'mcp/capabilities', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'mcp', children: [] },
+        { text: { en: 'Setup', fr: 'Installation', es: 'Configuración', ru: 'Настройка', zh: '设置', 'ar-ae': 'الإعداد' }, slug: 'mcp/setup', children: [] },
+        { text: { en: 'Capabilities', fr: 'Fonctionnalités', es: 'Capacidades', ru: 'Возможности', zh: '功能特性', 'ar-ae': 'الإمكانيات' }, slug: 'mcp/capabilities', children: [] },
       ]
     },
     {
-      text: 'Plugins',
+      text: { en: 'Plugins', fr: 'Plugins', es: 'Plugins', ru: 'Плагины', zh: '插件', 'ar-ae': 'الإضافات' },
       slug: 'plugins',
       icon: 'plugins',
       children: [
-        { text: 'Overview', slug: 'plugins', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'plugins', children: [] },
         { text: 'Assist', slug: 'plugins/assist', children: [] },
         { text: 'Axios', slug: 'plugins/axios', children: [] },
         { text: 'Fetch', slug: 'plugins/fetch', children: [] },
@@ -320,17 +324,17 @@ const nav: NavItem = {
         { text: 'NgRx', slug: 'plugins/ngrx', children: [] },
         { text: 'Pinia', slug: 'plugins/pinia', children: [] },
         { text: 'VueX', slug: 'plugins/vuex', children: [] },
-        { text: 'Profiler', slug: 'plugins/profiler', children: [] },
+        { text: { en: 'Profiler', fr: 'Profileur', es: 'Perfilador', ru: 'Профилировщик', zh: '性能分析', 'ar-ae': 'أداة التنميط' }, slug: 'plugins/profiler', children: [] },
         { text: 'Redux', slug: 'plugins/redux', children: [] },
         { text: 'Zustand', slug: 'plugins/zustand', children: [] },
       ]
     },
     {
-      text: 'Integrations',
+      text: { en: 'Integrations', fr: 'Intégrations', es: 'Integraciones', ru: 'Интеграции', zh: '集成', 'ar-ae': 'التكاملات' },
       slug: 'integrations',
       icon: 'integration',
       children: [
-        { text: 'Overview', slug: 'integrations', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'integrations', children: [] },
         { text: 'Datadog', slug: 'integrations/datadog', children: [] },
         { text: 'Elastic', slug: 'integrations/elastic', children: [] },
         { text: 'Dynatrace', slug: 'integrations/dynatrace', children: [] },
@@ -347,13 +351,13 @@ const nav: NavItem = {
       slug: 'api',
       icon: 'api',
       children: [
-        { text: 'Overview', slug: 'api', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'api', children: [] },
         { text: 'Assist', slug: 'api/assist', children: [] },
-        { text: 'Events', slug: 'api/events', children: [] },
-        { text: 'Jobs', slug: 'api/jobs', children: [] },
-        { text: 'Projects', slug: 'api/projects', children: [] },
-        { text: 'Sessions', slug: 'api/sessions', children: [] },
-        { text: 'Users', slug: 'api/users', children: [] },
+        { text: { en: 'Events', fr: 'Événements', es: 'Eventos', ru: 'События', zh: '事件', 'ar-ae': 'الأحداث' }, slug: 'api/events', children: [] },
+        { text: { en: 'Jobs', fr: 'Tâches', es: 'Trabajos', ru: 'Задания', zh: '任务', 'ar-ae': 'المهام' }, slug: 'api/jobs', children: [] },
+        { text: { en: 'Projects', fr: 'Projets', es: 'Proyectos', ru: 'Проекты', zh: '项目', 'ar-ae': 'المشاريع' }, slug: 'api/projects', children: [] },
+        { text: { en: 'Sessions', fr: 'Sessions', es: 'Sesiones', ru: 'Сессии', zh: '会话', 'ar-ae': 'الجلسات' }, slug: 'api/sessions', children: [] },
+        { text: { en: 'Users', fr: 'Utilisateurs', es: 'Usuarios', ru: 'Пользователи', zh: '用户', 'ar-ae': 'المستخدمون' }, slug: 'api/users', children: [] },
       ]
     },
     { 
@@ -364,7 +368,7 @@ const nav: NavItem = {
       children: [] 
     },
     {
-      text: 'Materials',
+      text: { en: 'Materials', fr: 'Ressources', es: 'Materiales', ru: 'Материалы', zh: '资料', 'ar-ae': 'المواد' },
       slug: null,
       icon: 'null',
       hideChevron: true,
@@ -372,42 +376,42 @@ const nav: NavItem = {
       isSectionTitle: true
     },
     {
-      text: 'Exporting data',
+      text: { en: 'Exporting data', fr: 'Exporter les données', es: 'Exportar datos', ru: 'Экспорт данных', zh: '导出数据', 'ar-ae': 'تصدير البيانات' },
       slug: 'structure',
       icon: 'structure',
       children: [
-        { text: 'Overview', slug: 'structure', children: [] },
-        { text: 'Exported Data', slug: 'structure/exported-data', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'structure', children: [] },
+        { text: { en: 'Exported Data', fr: 'Données exportées', es: 'Datos exportados', ru: 'Экспортированные данные', zh: '已导出数据', 'ar-ae': 'البيانات المصدَّرة' }, slug: 'structure/exported-data', children: [] },
       ]
     },
     {
-      text: 'Troubleshooting',
+      text: { en: 'Troubleshooting', fr: 'Dépannage', es: 'Solución de problemas', ru: 'Устранение неполадок', zh: '故障排除', 'ar-ae': 'استكشاف الأخطاء' },
       slug: 'troubleshooting',
       icon: 'troubleshoot',
       children: [
-        { text: 'Overview', slug: 'troubleshooting', children: [] },
-        { text: 'Clear Cache', slug: 'troubleshooting/cache', children: [] },
+        { text: { en: 'Overview', fr: 'Aperçu', es: 'Descripción general', ru: 'Обзор', zh: '概览', 'ar-ae': 'نظرة عامة' }, slug: 'troubleshooting', children: [] },
+        { text: { en: 'Clear Cache', fr: 'Vider le cache', es: 'Limpiar caché', ru: 'Очистить кэш', zh: '清除缓存', 'ar-ae': 'مسح ذاكرة التخزين المؤقت' }, slug: 'troubleshooting/cache', children: [] },
         { text: 'Content Security Policy (CSP)', slug: 'troubleshooting/csp', children: [] },
-        { text: 'JS Errors', slug: 'troubleshooting/js-errors', children: [] },
-        { text: 'Localhost Testing', slug: 'troubleshooting/localhost', children: [] },
-        { text: 'Session Recording Issues', slug: 'troubleshooting/session-recordings', children: [] },
-        { text: 'Sourcemaps Issues', slug: 'troubleshooting/sourcemaps', children: [] },
-        { text: 'Supported Browsers', slug: 'troubleshooting/supported-browsers', children: [] },
-        { text: 'Deployment Issues', slug: 'troubleshooting/deployment-issues', children: [] },
-				{ text: 'Network Resources', slug: 'troubleshooting/network-resources', children: [] },
+        { text: { en: 'JS Errors', fr: 'Erreurs JS', es: 'Errores JS', ru: 'Ошибки JS', zh: 'JS 错误', 'ar-ae': 'أخطاء JS' }, slug: 'troubleshooting/js-errors', children: [] },
+        { text: { en: 'Localhost Testing', fr: 'Tests en local', es: 'Pruebas en localhost', ru: 'Локальное тестирование', zh: '本地测试', 'ar-ae': 'الاختبار المحلي' }, slug: 'troubleshooting/localhost', children: [] },
+        { text: { en: 'Session Recording Issues', fr: 'Problèmes d\'enregistrement', es: 'Problemas de grabación', ru: 'Проблемы записи сессий', zh: '录制问题', 'ar-ae': 'مشكلات التسجيل' }, slug: 'troubleshooting/session-recordings', children: [] },
+        { text: { en: 'Sourcemaps Issues', fr: 'Problèmes de source maps', es: 'Problemas de source maps', ru: 'Проблемы source maps', zh: 'Source Maps 问题', 'ar-ae': 'مشكلات خرائط المصدر' }, slug: 'troubleshooting/sourcemaps', children: [] },
+        { text: { en: 'Supported Browsers', fr: 'Navigateurs pris en charge', es: 'Navegadores compatibles', ru: 'Поддерживаемые браузеры', zh: '支持的浏览器', 'ar-ae': 'المتصفحات المدعومة' }, slug: 'troubleshooting/supported-browsers', children: [] },
+        { text: { en: 'Deployment Issues', fr: 'Problèmes de déploiement', es: 'Problemas de despliegue', ru: 'Проблемы развёртывания', zh: '部署问题', 'ar-ae': 'مشكلات النشر' }, slug: 'troubleshooting/deployment-issues', children: [] },
+				{ text: { en: 'Network Resources', fr: 'Ressources réseau', es: 'Recursos de red', ru: 'Сетевые ресурсы', zh: '网络资源', 'ar-ae': 'موارد الشبكة' }, slug: 'troubleshooting/network-resources', children: [] },
       ]
     },
     {
-      text: 'Tutorials',
+      text: { en: 'Tutorials', fr: 'Tutoriels', es: 'Tutoriales', ru: 'Учебные пособия', zh: '教程', 'ar-ae': 'الدروس التعليمية' },
       slug: null,
       icon: 'tutorials',
       children: [
         { text: 'Assist', slug: 'tutorials/assist', children: [] },
-        { text: 'Build Plugins', slug: 'tutorials/build-plugins', children: [] },
-        { text: 'Custom Events', slug: 'tutorials/custom-events', children: [] },
-        { text: 'Capture and Sanitize', slug: 'tutorials/capture-request', children: [] },
+        { text: { en: 'Build Plugins', fr: 'Plugins de build', es: 'Plugins de compilación', ru: 'Плагины сборки', zh: '构建插件', 'ar-ae': 'إضافات البناء' }, slug: 'tutorials/build-plugins', children: [] },
+        { text: { en: 'Custom Events', fr: 'Événements personnalisés', es: 'Eventos personalizados', ru: 'Пользовательские события', zh: '自定义事件', 'ar-ae': 'الأحداث المخصصة' }, slug: 'tutorials/custom-events', children: [] },
+        { text: { en: 'Capture and Sanitize', fr: 'Capture et nettoyage', es: 'Captura y saneamiento', ru: 'Захват и очистка', zh: '采集与脱敏', 'ar-ae': 'الالتقاط والتنقية' }, slug: 'tutorials/capture-request', children: [] },
         { text: 'GraphQL', slug: 'tutorials/graphql', children: [] },
-        { text: 'Metadata', slug: 'tutorials/metadata', children: [] },
+        { text: { en: 'Metadata', fr: 'Métadonnées', es: 'Metadatos', ru: 'Метаданные', zh: '元数据', 'ar-ae': 'البيانات الوصفية' }, slug: 'tutorials/metadata', children: [] },
         { text: 'Redux', slug: 'tutorials/redux', children: [] },
         { text: 'VueX', slug: 'tutorials/vuex', children: [] },
         { text: 'Zustand', slug: 'tutorials/zustand', children: [] },
@@ -421,6 +425,22 @@ const nav: NavItem = {
       children: []
     }
   ]
+}
+
+/** Resolve a (possibly multilingual) nav label to a string for `lang` (English fallback). */
+export function resolveNavText(text: LocalizedText, lang: string): string {
+  if (typeof text === 'string') return text
+  return (text as Record<string, string>)[lang] ?? text.en
+}
+
+/** A copy of the nav tree with every label resolved to `lang`. */
+export function localizeNav(lang: string): NavItem {
+  const walk = (item: NavItem): NavItem => ({
+    ...item,
+    text: resolveNavText(item.text, lang),
+    children: item.children?.map(walk) ?? [],
+  })
+  return walk(nav)
 }
 
 export default nav

--- a/src/i18n/ru/ui.ts
+++ b/src/i18n/ru/ui.ts
@@ -17,4 +17,11 @@ export default UIDictionary({
 	'articleNav.prevPage': 'Назад',
 	'leftSidebar.learnTab': 'Изучить',
 	'leftSidebar.referenceTab': 'Ссылки',
+	'leftSidebar.a11yTitle': 'Основная навигация',
+	'leftSidebar.viewInEnglish': 'Посмотреть на английском',
+	'leftSidebar.sponsoredBy': 'При поддержке',
+	'rightSidebar.a11yTitle': 'Дополнительная навигация',
+	'rightSidebar.overview': 'Обзор',
+	'rightSidebar.joinSlack': 'Присоединиться к Slack',
+	'rightSidebar.github': 'Открыть на GitHub',
 });

--- a/src/i18n/util.ts
+++ b/src/i18n/util.ts
@@ -2,7 +2,7 @@ import type { AstroGlobal } from 'astro';
 import { readdir } from 'node:fs/promises';
 import { DocSearchTranslation, UIDict, UIDictionaryKeys } from './translation-checkers';
 import { getLanguageFromURL } from '../util';
-import { NavItem } from './en/nav';
+import { NavItem, localizeNav } from './en/nav';
 /**
  * Convert the map of modules returned by `import.meta.globEager` to an object
  * mapping the language code from each module’s filepath to the module’s default export.
@@ -64,8 +64,6 @@ const translations = mapDefaultExports<UIDict>(import.meta.glob('./*/ui.ts', { e
 const docsearchTranslations = mapDefaultExports<DocSearchTranslation>(
 	import.meta.glob('./*/docsearch.ts', { eager: true })
 );
-const navTranslations = mapDefaultExports<NavItem>(import.meta.glob('./*/nav.ts', { eager: true }));
-
 const fallbackLang = 'en';
 
 /** Returns a dictionary of strings for use with DocSearch. */
@@ -78,7 +76,9 @@ export function getDocSearchStrings(Astro: AstroGlobal): DocSearchTranslation {
 /** Get the navigation sidebar content for the current language. */
 export async function getNav(Astro: AstroGlobal): Promise<NavItem> {
 	const lang = getLanguageFromURL(Astro.url.pathname) || fallbackLang;
-	return await markFallbackNavEntries(lang, navTranslations[lang]);
+	// The menu is defined once (structure + routes + inline translations) in en/nav.ts.
+	// localizeNav resolves every label to the current language (English fallback).
+	return await markFallbackNavEntries(lang, localizeNav(lang));
 }
 
 /**

--- a/src/i18n/zh/ui.ts
+++ b/src/i18n/zh/ui.ts
@@ -1,3 +1,19 @@
 import { UIDictionary } from '../translation-checkers';
 
-export default UIDictionary({});
+export default UIDictionary({
+	'leftSidebar.a11yTitle': '主要',
+	'leftSidebar.learnTab': '学习',
+	'leftSidebar.referenceTab': '参考',
+	'leftSidebar.viewInEnglish': '查看英文版',
+	'leftSidebar.sponsoredBy': '赞助方',
+	'rightSidebar.a11yTitle': '次要',
+	'rightSidebar.onThisPage': '本页内容',
+	'rightSidebar.overview': '概览',
+	'rightSidebar.community': '社区',
+	'rightSidebar.joinSlack': '加入 Slack 社区',
+	'rightSidebar.readBlog': '博客',
+	'rightSidebar.contribute': '贡献',
+	'rightSidebar.editPage': '编辑此页',
+	'rightSidebar.translatePage': '翻译此页',
+	'rightSidebar.github': '浏览 GitHub',
+});


### PR DESCRIPTION
## Summary

The left sidebar menu was authored only in English (`src/i18n/en/nav.ts`) and rendered in English on every localized page. This adds **central, inline translations** to that single file so the menu is translated in one place — add a section once, get it in all languages.

## How it works
- **`en/nav.ts`** — `NavItem.text` now accepts a `LocalizedText` object: `{ en, fr, es, ru, zh, 'ar-ae' }`. Descriptive labels carry inline translations (116 occurrences across ~80 unique labels); brand / product / framework / API-method names (`OpenReplay`, `JavaScript`, `Assist`, `setMetadata`, `AWS`, …) stay plain strings. Adds `resolveNavText()` + `localizeNav(lang)` (English fallback).
- **`util.ts` `getNav()`** — resolves the one central tree to the current language. This supersedes the per-language `nav.ts` `NavDictionary` stubs (which were 7–49 lines and only partially translated). Sidebar components are unchanged — they receive resolved strings.
- **`ui.ts`** — filled the missing left/right-sidebar UI strings (tabs `Learn`/`Reference`, right-menu header `On this page`, `Overview`, community/contribute/edit links) for **zh** and **ar-ae** (were empty) and **ru** (partial), so the right-menu header and sidebar chrome localize too.

The right-menu items themselves are page headings (already translated via page content); only its header/chrome came from `ui.ts`.

## Coverage
The nav tree is version-agnostic (version is just a URL prefix added at render time), so this translates the menu for **all versions** at once.

## Verification
- `localizeNav` resolves `fr` / `zh` / `ar-ae` correctly (brand names preserved).
- Live render of `/fr/home`: sidebar shows `Démarrage rapide`, `Déploiement`, `Configuration`, `Plateforme`, `Produits`, `Intégrations`, `Dépannage`, `Tutoriels`, `Aperçu`; `JavaScript` / `SDKs` / `Assist` intact.

## Adding a new section later
Add one `NavItem` in `en/nav.ts` with `text: { en, fr, es, ru, zh, 'ar-ae' }` (or a plain string if it shouldn't be translated). That's the only edit.

## Follow-up (not in this PR)
`src/i18n/{fr,es,ru,zh,ar-ae}/nav.ts` are now unused and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
