### PR TITLE
Make local dev usable on memory-constrained machines (dev:jit + skip fallback glob in dev)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "dev:jit": "NODE_OPTIONS=--max_old_space_size=8192 astro dev",
     "build": " NODE_OPTIONS=--max_old_space_size=30000 astro build",
     "postbuild": "node scripts/prepare-index.js && node scripts/index-to-algolia.cjs && node scripts/format-sitemap.mjs",
     "preview": "astro preview",

--- a/src/pages/[lang]/[...fallback].astro
+++ b/src/pages/[lang]/[...fallback].astro
@@ -3,6 +3,13 @@ import languages from '../../i18n/languages';
 import { groupPagesByLang } from '../../util/groupPagesByLang';
 
 export async function getStaticPaths() {
+	// Computing fallback redirects requires globbing every page in every language.
+	// `astro build` does this once; but in `astro dev` it fires on the first navigation
+	// under /[lang]/… and forces Vite to load thousands of page modules at once, which
+	// times out (60s `fetchModule`) and makes the dev server appear to hang. Fallbacks
+	// only matter for the static build — skip them in dev; real (translated) pages still
+	// resolve via their own routes.
+	if (import.meta.env.DEV) return [];
 	const allPages = await Astro.glob('../**/*.mdx');
 	const pagesByLang = groupPagesByLang(allPages);
 


### PR DESCRIPTION
## Summary

The fully-translated site (~12,700 pages × 6 languages) can't be built or comfortably dev-served on a typical laptop. Two small changes make **local dev** work for checking individual pages, without touching production build/deploy behavior.

### 1. `dev:jit` script (`package.json`)
The full static build needs ~30 GB heap (#267). `astro dev` only compiles pages on demand, but needs more heap than Node's default for a site this large:
```json
"dev:jit": "NODE_OPTIONS=--max_old_space_size=8192 astro dev"
```
Run `npm run dev:jit`, open the page you want — Astro compiles just that page.

### 2. Skip the i18n fallback glob in dev (`src/pages/[lang]/[...fallback].astro`)
`getStaticPaths` globs **every `.mdx` in every language** (~12.7k modules via `Astro.glob`) to compute fallback redirects. In `astro build` that's a one-time cost, but in `astro dev` it fires on the first navigation under `/[lang]/…` and forces Vite to load thousands of modules at once → 60s `fetchModule` timeouts → **the dev server hangs on every link click**. Now that every page is translated this produces ~zero fallbacks anyway. Guarded with `if (import.meta.env.DEV) return []` — real pages still resolve via their own routes; the production build is unchanged.

## Verified
With both changes, on a 16 GB machine: fresh-page navigation went from **>180 s (hang)** to **0.05–0.35 s**, and dev memory from ~3.4 GB to **~1 GB**. Confirmed across `/en`, `/fr`, `/zh` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
