### PR TITLE
chore: gitignore local .claude/ launch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ public/search-index.json
 !public/images/ai/
 !public/images/products/
 !public/images/javascript-sdk/
+# Local Claude Code launch config (preview tool); not project content
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore`. That directory holds the local `launch.json` used to run the dev server via the preview tooling — per-developer config, not project content. Keeps `git status` clean on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)