### PR TITLE
Fix RTL display: LTR code blocks + nav icon spacing

### DIFF
--- a/src/components/LeftSidebar/NavItem.tsx
+++ b/src/components/LeftSidebar/NavItem.tsx
@@ -118,7 +118,7 @@ function NavItem({ item, currentPageNoLangNoVer, categoryLinkPrefix, level = 0 }
         </a>
         {hasChildren && !item.hideChevron && (
           <div 
-            className={`px-2 cursor-pointer transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}
+            className={`px-2 cursor-pointer transition-transform duration-200 ${isOpen ? 'rotate-90' : 'rtl:rotate-180'}`}
             onClick={handleChevronClick}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" > <polyline points="9 18 15 12 9 6"></polyline> </svg>

--- a/src/components/LeftSidebar/NavItem.tsx
+++ b/src/components/LeftSidebar/NavItem.tsx
@@ -113,7 +113,7 @@ function NavItem({ item, currentPageNoLangNoVer, categoryLinkPrefix, level = 0 }
         <a href={hrefValue} onClick={handleClick} className={`w-full px-2 py-1 rounded ${ shouldBeHighlighted ? 'text-accent font-medium' : 'text-readable-grey' }`} >
           <div className="flex items-center">
             {item.icon && <MenuIcon icon={item.icon} />}
-            <span className="ml-2">{item.text}</span>
+            <span className="ms-2">{item.text}</span>
           </div>
         </a>
         {hasChildren && !item.hideChevron && (

--- a/src/components/LeftSidebar/SidebarContent.astro
+++ b/src/components/LeftSidebar/SidebarContent.astro
@@ -22,7 +22,7 @@ const currentPageNoLangNoVer = currentPageMatch.replace(`${lang}/`, '').replace(
 
   <ul>
     {sidebarSections.map((section, index) => section.isSectionTitle ? (
-      <div class="ml-2 text-black-300 font-bold my-2">
+      <div class="ms-2 text-black-300 font-bold my-2">
         {section.text}
       </div>
     ) :

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -107,3 +107,13 @@ if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/
         @apply opacity-100 pointer-events-auto;
     }
 </style>
+
+<style is:global>
+	/* Code blocks are always English/LTR — keep them left-aligned even on RTL
+	   (e.g. Arabic) pages, where they'd otherwise inherit right alignment. */
+	.astro-code,
+	.code-snippet {
+		direction: ltr;
+		text-align: left;
+	}
+</style>


### PR DESCRIPTION
Two display bugs on Arabic (RTL) pages, reported from `/ar-ae`:

1. **Code blocks were right-aligned.** Code is always English, so it should read left-to-right. Added a global rule (`BaseLayout.astro`) forcing `direction: ltr; text-align: left` on `.astro-code` (Shiki) and `.code-snippet`. No-op on LTR pages.
2. **Sidebar icons sat flush against the label.** `NavItem.tsx` used `ml-2` (physical `margin-left`), which doesn't flip in RTL. Switched to the logical `ms-2` (`margin-inline-start`) so the icon/text gap is correct in both directions.

Verified live on `/ar-ae/plugins/assist`: the 13 code blocks now compute `direction: ltr` / `text-align: left`, and the nav label computes `margin-right: 8px` (the RTL-correct gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)