### PR TITLE
mobile: fix iOS Safari drawer overlap, search field, viewport height & Spot icon

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -62,7 +62,8 @@ html {
 
 body {
 	color: var(--theme-text);
-	min-height: 100vh;
+	min-height: 100vh; /* fallback for browsers without dvh */
+	min-height: 100dvh; /* iOS Safari: excludes the retracted toolbar strip → no bottom gap */
 	font-family: var(--font-body);
 	font-size: 16px;
 	line-height: 1.5;

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -112,6 +112,28 @@ body.mobile-sidebar-toggle #mobile-overlay { opacity: 1 !important; pointer-even
 	}
 }
 
+/* The mobile drawer footer (.or-mobile-footer > .or-mobile-theme) already supplies
+   the theme toggle. LeftSidebar still ships a legacy in-sidebar ThemeToggleButton
+   (isInsideHeader=false → .theme-toggle-pill:not(.in-header)) that duplicates it and
+   crowds/overlaps the bottom nav rows in the drawer. Hide the legacy one in the
+   sidebar contexts; the LanguageSelect in that row stays. The header toggle
+   (.in-header) is unaffected. */
+.or-drawer .theme-toggle-pill:not(.in-header),
+.or-left .theme-toggle-pill:not(.in-header) {
+	display: none !important;
+}
+
+/* The drawer (#mobile-left-sidebar) and left sidebar scroll as a whole, so their
+   <nav> must size to its content and let the footer flow BELOW all nav rows.
+   LeftSidebar's nav carries Tailwind `h-full` (height:100%), which caps the nav
+   box to the container height while its rows overflow *visibly* past it — the
+   footer (theme toggle / social links / language) was then painted ON TOP of the
+   mid-list nav rows. Override h-full so the nav grows to its real height. */
+.or-drawer .or-sidenav,
+.or-left .or-sidenav {
+	height: auto;
+}
+
 /* hide the legacy mobile TOC bar — design hides TOC on small screens */
 .fixed-mobile-bar { display: none !important; }
 
@@ -862,6 +884,9 @@ body.or-home-page .content h2 { font-size: 27px; }
 }
 .content a.lh-spot:hover { color: var(--text); border-color: var(--accent-ring); box-shadow: var(--shadow-md); }
 .content .lh-spot .lh-cico { width: 38px; height: 38px; flex: none; border-radius: 10px; background: var(--surface); color: var(--accent); display: flex; align-items: center; justify-content: center; }
+/* Without an explicit size, Safari/WebKit resolves this no-width/height inline SVG
+   flex item to 0×0 and the icon disappears (Blink/Gecko infer it from viewBox). */
+.content .lh-spot .lh-cico svg { width: 19px; height: 19px; }
 .content .lh-spot h4 { font-family: var(--fd); font-weight: 700; font-size: 15px; margin: 0 0 2px; color: var(--text); }
 .content .lh-spot p { font-size: 12.5px; color: var(--text-2); margin: 0; }
 .content .lh-spot .lh-arr { margin-left: auto; color: var(--accent); opacity: 0.5; transition: transform 0.2s ease, opacity 0.2s ease; }

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -123,14 +123,15 @@ body.mobile-sidebar-toggle #mobile-overlay { opacity: 1 !important; pointer-even
 	display: none !important;
 }
 
-/* The drawer (#mobile-left-sidebar) and left sidebar scroll as a whole, so their
-   <nav> must size to its content and let the footer flow BELOW all nav rows.
+/* In the mobile drawer the <nav> and the footer (.or-mobile-footer) are siblings,
+   so the nav must size to its content and let the footer flow BELOW all nav rows.
    LeftSidebar's nav carries Tailwind `h-full` (height:100%), which caps the nav
-   box to the container height while its rows overflow *visibly* past it — the
-   footer (theme toggle / social links / language) was then painted ON TOP of the
-   mid-list nav rows. Override h-full so the nav grows to its real height. */
-.or-drawer .or-sidenav,
-.or-left .or-sidenav {
+   box to the drawer height while its rows overflow *visibly* past it — the footer
+   (theme toggle) was then painted ON TOP of the mid-list nav rows. Override h-full
+   here so the nav grows to its real height. Scoped to the drawer only: the desktop
+   `.or-left` keeps its in-nav footer as a flow list-item (not a sibling), so it has
+   no overlap and needs no override. */
+.or-drawer .or-sidenav {
 	height: auto;
 }
 

--- a/src/components/Header/DocSearch.css
+++ b/src/components/Header/DocSearch.css
@@ -98,12 +98,22 @@
 		top: 46px;
 	}
 
+	/* Modal stays full-bleed on mobile, but the search FIELD keeps the desktop
+	   rounded, soft-surface look (it was previously squared to border-radius:0,
+	   which is why mobile search didn't match desktop). */
 	.DocSearch-Modal {
 		border-radius: 0!important;
 	}
 
 	.DocSearch-Form {
-		border-radius: 0!important;
+		border-radius: 10px;
+		background: var(--surface-2);
+		box-shadow: inset 0 0 0 1px var(--or-border);
+		padding: 0 12px;
+	}
+	.DocSearch-Form:focus-within {
+		background: var(--surface);
+		box-shadow: inset 0 0 0 1px var(--accent-ring), 0 0 0 3px var(--accent-soft);
 	}
 
 	.DocSearch.DocSearch-Container{

--- a/src/components/Header/DocSearch.css
+++ b/src/components/Header/DocSearch.css
@@ -98,22 +98,17 @@
 		top: 46px;
 	}
 
-	/* Modal stays full-bleed on mobile, but the search FIELD keeps the desktop
-	   rounded, soft-surface look (it was previously squared to border-radius:0,
-	   which is why mobile search didn't match desktop). */
+	/* Modal stays full-bleed on mobile. The search FIELD was squared to
+	   border-radius:0 here, which is why mobile search didn't match desktop;
+	   just restore the radius so it inherits the desktop rounded, soft-surface
+	   look (background / border / focus-ring come from the global .DocSearch-Form
+	   rule above, which applies at every width). */
 	.DocSearch-Modal {
 		border-radius: 0!important;
 	}
 
 	.DocSearch-Form {
 		border-radius: 10px;
-		background: var(--surface-2);
-		box-shadow: inset 0 0 0 1px var(--or-border);
-		padding: 0 12px;
-	}
-	.DocSearch-Form:focus-within {
-		background: var(--surface);
-		box-shadow: inset 0 0 0 1px var(--accent-ring), 0 0 0 3px var(--accent-soft);
 	}
 
 	.DocSearch.DocSearch-Container{


### PR DESCRIPTION
## Summary

Fixes four **iPhone Safari**–specific bugs reported in the 2026 redesign while testing the docs on a real device. All fixes live in **shared / global CSS**, so they propagate to every locale and version automatically (no per-page MDX edits).

| Bug | Root cause | Fix |
|---|---|---|
| Extra theme toggle **overlapping the nav menu** | LeftSidebar's `<nav>` carries Tailwind `h-full` (`height:100%`), capping its layout box to the container height while its rows overflow *visibly* past it — so the footer (theme toggle) was painted **on top of** the mid-list nav rows. There was also a duplicate legacy in-sidebar toggle. | Let the drawer/left-sidebar nav size to its content (`height:auto`), and hide the legacy duplicate `ThemeToggleButton` (the redesign `.or-mobile-footer` toggle already covers it). Language select stays. |
| Mobile **search field** doesn't match desktop (square corners) | The `@media (max-width:750px)` block forced `.DocSearch-Form { border-radius: 0 }`. | Restore the desktop rounded, soft-surface field on mobile (`10px` radius + inset border + accent focus ring). Modal stays full-bleed. |
| Page **not full height on iPhone** (gap above the Safari toolbar) | `body { min-height: 100vh }` — on iOS `100vh` is the *large* viewport (includes the retracted toolbar strip), so the body exceeds the visible area. | Add a `100dvh` companion declaration (plain `100vh` kept first as a fallback). |
| **Spot icon empty** on Safari | The `.lh-spot` card's inline SVG has a `viewBox` but no `width`/`height` and no CSS size rule; WebKit resolves a sizeless SVG flex item to `0×0` (Blink/Gecko infer it from the viewBox). | Add the missing `.lh-spot .lh-cico svg { width:19px; height:19px }` rule. |

## Files
- `public/redesign.css` — nav `height:auto`, hide legacy duplicate toggle, Spot icon SVG size
- `public/index.css` — `body` `min-height: 100dvh`
- `src/components/Header/DocSearch.css` — mobile search field styling

## Verification
Driven with Playwright's **WebKit** engine (the actual Safari rendering engine) at an iPhone viewport:
- Spot card SVG now resolves to **19×19** (was 0×0)
- Drawer has a **single** theme toggle, positioned in the bottom footer below all nav rows — DOM probe confirms no toggle SVG overlaps the nav (was overlapping the "Integrations"/"Troubleshooting" rows)
- `.DocSearch-Form` computes `border-radius: 10px` with the accent focus ring
- `body` `min-height` resolves via `dvh`
- Desktop (1440px) left sidebar still scrolls correctly — no regression

> Note: the `100dvh` fix is the standard remedy and is confirmed to parse/resolve in WebKit; the on-device toolbar gap can only be 100% confirmed on a physical iPhone (headless browsers have no dynamic toolbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)