### PR TITLE
mobile: fix iOS full-height gap, drawer header/scroll, theme+language row & 404 robot

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -62,8 +62,14 @@ html {
 
 body {
 	color: var(--theme-text);
+	/* Establish a block formatting context so the app shell's `margin-top` (the
+	   navbar offset) is contained instead of collapsing through the body and adding
+	   the navbar height to the scrollable document. That stray document overflow let
+	   iOS Safari's toolbar engage on scroll and left a gap ("not full height") at the
+	   bottom of the viewport. */
+	display: flow-root;
 	min-height: 100vh; /* fallback for browsers without dvh */
-	min-height: 100dvh; /* iOS Safari: excludes the retracted toolbar strip → no bottom gap */
+	min-height: 100dvh; /* dynamic viewport height (iOS Safari) */
 	font-family: var(--font-body);
 	font-size: 16px;
 	line-height: 1.5;

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -81,56 +81,33 @@ body {
 	border-inline-end: 1px solid var(--or-border);
 	transform: translateX(-100%);
 	transition: transform 0.25s ease;
+	/* Keep scroll momentum inside the drawer instead of chaining to the page behind
+	   it (which made it hard to scroll the menu back up on iOS). */
+	overscroll-behavior: contain;
 }
 [dir='rtl'] .or-drawer { transform: translateX(100%); }
 body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); }
 #mobile-overlay { transition: opacity 0.25s ease; }
 body.mobile-sidebar-toggle #mobile-overlay { opacity: 1 !important; pointer-events: auto !important; }
 
-/* mobile drawer footer */
-.or-mobile-footer { display: none; }
-@media (max-width: 768px) {
-	.or-mobile-footer {
-		display: flex;
-		align-items: center;
-		gap: 10px;
-		margin: 18px 14px;
-		padding-top: 16px;
-		border-top: 1px solid var(--or-border);
-	}
-	.or-mobile-theme {
-		width: 38px;
-		height: 38px;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		border-radius: 9999px;
-		border: 1px solid var(--or-border);
-		background: var(--surface);
-		color: var(--text-2);
-		cursor: pointer;
-	}
+/* When the drawer is open, lock the background page scroll (.or-main) so touch
+   scrolling stays inside the drawer instead of chaining into the page behind it. */
+body.mobile-sidebar-toggle .or-main { overflow: hidden; }
+
+/* The header has a translucent background + backdrop blur. The dark #mobile-overlay
+   sits behind it, so the blur sampled the overlay and turned the header grey when the
+   drawer opened. Make the header solid (no blur) while the drawer is open. */
+body.mobile-sidebar-toggle header {
+	background: var(--page);
+	-webkit-backdrop-filter: none;
+	backdrop-filter: none;
 }
 
-/* The mobile drawer footer (.or-mobile-footer > .or-mobile-theme) already supplies
-   the theme toggle. LeftSidebar still ships a legacy in-sidebar ThemeToggleButton
-   (isInsideHeader=false → .theme-toggle-pill:not(.in-header)) that duplicates it and
-   crowds/overlaps the bottom nav rows in the drawer. Hide the legacy one in the
-   sidebar contexts; the LanguageSelect in that row stays. The header toggle
-   (.in-header) is unaffected. */
-.or-drawer .theme-toggle-pill:not(.in-header),
-.or-left .theme-toggle-pill:not(.in-header) {
-	display: none !important;
-}
-
-/* In the mobile drawer the <nav> and the footer (.or-mobile-footer) are siblings,
-   so the nav must size to its content and let the footer flow BELOW all nav rows.
-   LeftSidebar's nav carries Tailwind `h-full` (height:100%), which caps the nav
-   box to the drawer height while its rows overflow *visibly* past it — the footer
-   (theme toggle) was then painted ON TOP of the mid-list nav rows. Override h-full
-   here so the nav grows to its real height. Scoped to the drawer only: the desktop
-   `.or-left` keeps its in-nav footer as a flow list-item (not a sibling), so it has
-   no overlap and needs no override. */
+/* In the mobile drawer the whole <nav> scrolls. LeftSidebar's nav carries Tailwind
+   `h-full` (height:100%), which caps the nav box to the drawer height while its
+   content (nav rows + the theme/language footer row) overflows past it. Let the nav
+   size to its real height so the drawer scrolls cleanly. Scoped to the drawer; the
+   desktop `.or-left` is unaffected. */
 .or-drawer .or-sidenav {
 	height: auto;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -56,16 +56,6 @@ const breadcrumb = getBreadcrumb(currentPage);
 			class="md:hidden fixed top-14 bottom-0 left-0 w-[300px] max-w-[85vw] overflow-y-auto z-50 or-noscroll or-drawer"
 		>
 			<LeftSidebar {currentPage} />
-			<div class="or-mobile-footer">
-				<button
-					type="button"
-					class="or-mobile-theme"
-					aria-label="Toggle theme"
-					onclick="(function(){var r=document.documentElement;var d=r.classList.toggle('theme-dark');r.classList.toggle('theme-light',!d);try{localStorage.setItem('theme',d?'dark':'light')}catch(e){}})()"
-				>
-					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"></path></svg>
-				</button>
-			</div>
 		</aside>
 
 		{/* Mobile Background Overlay */}

--- a/src/pages/[lang]/404.astro
+++ b/src/pages/[lang]/404.astro
@@ -77,6 +77,61 @@ const t = useTranslations(Astro);
 	/* ---- Animated 404 robot ("The Yank") + page chrome ----
 	   Everything is namespaced under .or-404 so nothing leaks. Keyframes are global
 	   (not Astro-scoped) so the SVG's inline `animation:` references resolve. */
+
+	/* "The Yank" loop (3.8s): the robot tugs its power cord, a spark pops at the
+	   outlet, its screen flickers out, and it recoils — then recovers and repeats.
+	   The arm group (r4_yank) has no transform-origin, so it only translates; the
+	   body/antenna/spark/shadow groups set transform-box:fill-box inline and rotate
+	   or scale about their own box. */
+	@keyframes r4_yank {
+		0%, 18%   { transform: translate(0, 0); }
+		30%       { transform: translate(-10px, -4px); } /* pull the cord taut */
+		40%       { transform: translate(4px, 2px); }    /* it pops loose */
+		55%, 100% { transform: translate(0, 0); }
+	}
+	@keyframes r4_rock {
+		0%, 22%   { transform: rotate(0deg); }
+		32%       { transform: rotate(2.5deg); }   /* lean into the pull */
+		42%       { transform: rotate(-4.5deg); }  /* recoil from the jolt */
+		54%       { transform: rotate(2deg); }
+		64%       { transform: rotate(-1deg); }
+		74%, 100% { transform: rotate(0deg); }
+	}
+	@keyframes r4_whip {
+		0%, 22%   { transform: rotate(0deg); }
+		34%       { transform: rotate(12deg); }
+		44%       { transform: rotate(-14deg); }   /* antenna snaps back */
+		56%       { transform: rotate(7deg); }
+		66%       { transform: rotate(-3deg); }
+		76%, 100% { transform: rotate(0deg); }
+	}
+	@keyframes r4_spark {
+		0%, 33%   { opacity: 0; transform: scale(0.4); }
+		37%       { opacity: 1; transform: scale(1.15); } /* flash at the outlet */
+		46%       { opacity: 0; transform: scale(0.6); }
+		100%      { opacity: 0; }
+	}
+	@keyframes r4_glow {
+		0%, 34%   { opacity: 0.85; }
+		37%       { opacity: 0.25; }  /* flicker as power is cut */
+		40%       { opacity: 0; }     /* lights out */
+		82%       { opacity: 0; }
+		90%       { opacity: 0.5; }   /* power restored */
+		100%      { opacity: 0.85; }
+	}
+	@keyframes r4_off {
+		0%, 38%   { opacity: 0; }
+		41%       { opacity: 1; }     /* dark screen overlay shows */
+		82%       { opacity: 1; }
+		92%, 100% { opacity: 0; }     /* screen comes back on */
+	}
+	@keyframes r4_shadow {
+		0%, 22%   { transform: scaleX(1); opacity: 1; }
+		42%       { transform: scaleX(0.9); opacity: 0.78; } /* recoil lifts it slightly */
+		64%       { transform: scaleX(1.03); opacity: 1; }
+		74%, 100% { transform: scaleX(1); opacity: 1; }
+	}
+
 	.or-404 {
 		text-align: center;
 		max-width: 560px;


### PR DESCRIPTION
## Summary

Follow-up fixes from on-device iPhone testing after #278. Four issues, fixed in shared CSS / layout (propagates to every locale and version). Verified in the **WebKit (Safari) engine** at an iPhone viewport; desktop unaffected.

| Issue | Root cause | Fix |
|---|---|---|
| **Page not full height** (gap at bottom on iOS) | The app shell's `margin-top` (navbar offset) collapsed *through* `<body>` and stacked on `min-height:100dvh`, adding the navbar height to the scrollable document (~56px of document overflow). On iOS that let the Safari toolbar engage on scroll and left a bottom gap. | Give `<body>` `display: flow-root` to contain the margin. Document overflow → 0; the shell / `.or-main` still own scrolling. |
| **Header turns grey when menu opens** | The header has a translucent background + `backdrop-filter: blur()`. The dark full-screen `#mobile-overlay` sits *behind* it, so the blur sampled the overlay. | Make the header solid (opaque `--page`, no blur) while the drawer is open. |
| **Can't scroll the open drawer back up** | When the drawer was open, the background `.or-main` still scrolled, so drawer scroll chained into the page behind it. | Lock `.or-main` scroll while the drawer is open + `overscroll-behavior: contain` on the drawer. |
| **Theme toggle alone, not next to language** | #278 hid LeftSidebar's in-nav toggle and kept a separate standalone `.or-mobile-footer` toggle at the very bottom. | Remove the redundant standalone toggle; keep LeftSidebar's toggle, which sits in the same row as the language selector (and properly swaps sun/moon). |
| **404 robot static** | The `@keyframes r4_*` referenced by the SVG's inline `animation:` were **never defined anywhere in the repo** — the animation never ran on any platform. | Add the missing keyframes ("The Yank": tug the cord, spark, lights-out, recoil). |

## Files
- `public/index.css` — `body { display: flow-root }`
- `public/redesign.css` — drawer `overscroll-behavior`, background scroll lock + solid header on menu open; remove the redundant standalone-toggle CSS and #278's toggle-hide
- `src/layouts/BaseLayout.astro` — remove the redundant `.or-mobile-footer` markup
- `src/pages/[lang]/404.astro` — add the missing `@keyframes`

## Verification (WebKit @ iPhone viewport)
- Document overflow: **0** (was 56px) → no bottom gap
- Header on menu open: `rgb(250,250,249)` opaque, `backdrop-filter: none` (was translucent/blurred-grey)
- `.or-main` overflow `hidden` + drawer `overscroll-behavior: contain` when open
- Theme toggle visible **in the same row as the language selector**; standalone toggle removed; no nav overlap
- 404: `getAnimations()` returns **7** resolved `r4_*` animations and the robot's transforms change over time (was 0 animations / static)
- Desktop (1440px) shell fills, scrolls, header toggle present — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)