### PR TITLE
mobile: let the document scroll on phones so iOS Safari retracts its toolbar

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -53,6 +53,16 @@ body {
 	overflow-y: auto;
 }
 
+/* Phone (the sidebar is a drawer and the TOC is hidden): drop the app shell's inner
+   scroll and let the DOCUMENT scroll instead. iOS Safari only retracts its toolbar on
+   a root-level scroll — with an inner scroller it stayed pinned and the page lost that
+   toolbar's worth of height ("not full height" on Safari; Chrome has no such toolbar,
+   so it looked fine). */
+@media (max-width: 767.98px) {
+	.or-shell { height: auto; overflow: visible; }
+	.or-main { overflow: visible; }
+}
+
 .or-main-wrap {
 	display: flex;
 	align-items: flex-start;
@@ -90,9 +100,11 @@ body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translate
 #mobile-overlay { transition: opacity 0.25s ease; }
 body.mobile-sidebar-toggle #mobile-overlay { opacity: 1 !important; pointer-events: auto !important; }
 
-/* When the drawer is open, lock the background page scroll (.or-main) so touch
-   scrolling stays inside the drawer instead of chaining into the page behind it. */
-body.mobile-sidebar-toggle .or-main { overflow: hidden; }
+/* When the drawer is open, lock the page scroll behind it. On phones the document is
+   the scroller (see the media query above), so lock the document itself — not .or-main
+   — and overscroll-behavior:contain on the drawer keeps touch scrolling inside it. */
+html:has(body.mobile-sidebar-toggle),
+body.mobile-sidebar-toggle { overflow: hidden; }
 
 /* The header has a translucent background + backdrop blur. The dark #mobile-overlay
    sits behind it, so the blur sampled the overlay and turned the header grey when the

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -97,7 +97,11 @@ body {
 }
 [dir='rtl'] .or-drawer { transform: translateX(100%); }
 body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); }
-#mobile-overlay { transition: opacity 0.25s ease; }
+/* touch-action:none stops a drag on the overlay from scrolling the page behind the
+   drawer. On phones the document is the scroller, where `overflow:hidden` is an
+   unreliable lock on iOS Safari; this (plus the drawer's overscroll-behavior:contain)
+   keeps the background fixed. Taps still fire, so tap-to-close keeps working. */
+#mobile-overlay { transition: opacity 0.25s ease; touch-action: none; }
 body.mobile-sidebar-toggle #mobile-overlay { opacity: 1 !important; pointer-events: auto !important; }
 
 /* When the drawer is open, lock the page scroll behind it. On phones the document is


### PR DESCRIPTION
## Summary

The "page not full height" gap **persisted on Safari only** (Chrome was fine), and the user noticed Safari's bottom toolbar **never retracts on scroll** the way it does on normal sites. That clue pinpointed the root cause.

**Root cause:** the app shell keeps its desktop *inner-scroll* model on phones — `.or-shell` is `height: calc(100dvh - navbar)` + `overflow: hidden`, and `.or-main` is the `overflow-y: auto` scroller. iOS Safari only retracts its bottom toolbar on a **root-level document scroll**. With an inner scroller the document never scrolls, so the toolbar stays pinned and the viewport is permanently short by the toolbar's height. Chrome has no retracting toolbar, so it looked correct.

**Fix:** on phones (`<768px`, where the sidebar is already a drawer and the TOC is hidden) drop the inner scroll and let the **document** scroll:

```css
@media (max-width: 767.98px) {
  .or-shell { height: auto; overflow: visible; }
  .or-main  { overflow: visible; }
}
```

Now the document scrolls, Safari retracts the toolbar like any normal page, and the page gets full height. The fixed header stays put. The drawer-open scroll lock is retargeted from `.or-main` to the document (`html`/`body`), since the document is now the scroller; the drawer's `overscroll-behavior: contain` still keeps touch scrolling inside it.

**Desktop & tablet are untouched** — they keep the inner-scroll app shell, and the TOC scroll-spy / back-to-top (which key off `#or-main-scroll`) keep working.

## Verification (WebKit @ iPhone viewport)
- Document scrolls: `docScrollRange 1613` (was 0 — inner-only); `.or-main` no longer scrolls
- Header stays `position: fixed` / pinned at top while the document scrolls
- No horizontal overflow introduced
- Drawer open: document scroll locked (`html`/`body` overflow hidden), header still opaque, theme toggle still next to language, drawer overscroll contained
- Desktop (1440px): `.or-main` still `overflow: auto` (inner scroll), shell still `100dvh`/`overflow:hidden`, TOC present — no regression

> Note: headless WebKit can't simulate the dynamic toolbar, so this is verified at the mechanism level (the document is now the scroller, which is what drives Safari's toolbar retraction). Worth a final confirmation on the physical iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)