### PR TITLE
mobile: stop locking root scroll on drawer open (fixes stuck iOS toolbar gap)

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -104,11 +104,12 @@ body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translate
 #mobile-overlay { transition: opacity 0.25s ease; touch-action: none; }
 body.mobile-sidebar-toggle #mobile-overlay { opacity: 1 !important; pointer-events: auto !important; }
 
-/* When the drawer is open, lock the page scroll behind it. On phones the document is
-   the scroller (see the media query above), so lock the document itself — not .or-main
-   — and overscroll-behavior:contain on the drawer keeps touch scrolling inside it. */
-html:has(body.mobile-sidebar-toggle),
-body.mobile-sidebar-toggle { overflow: hidden; }
+/* We deliberately do NOT lock the page scroll with `overflow:hidden` on html/body when
+   the drawer opens. On phones the document is the scroller, and toggling overflow on the
+   ROOT scroller makes iOS Safari snap its toolbar back to the expanded state and leaves a
+   stuck black gap at the bottom that persists even after the drawer closes. Background
+   containment is handled instead without touching the root scroller: the drawer's
+   overscroll-behavior:contain (above) plus the overlay's touch-action:none (above). */
 
 /* The header has a translucent background + backdrop blur. The dark #mobile-overlay
    sits behind it, so the blur sampled the overlay and turned the header grey when the


### PR DESCRIPTION
## Summary

Follow-up to #280. The full-height fix works on navigation (the document scrolls, Safari retracts its toolbar) — but **opening the menu reintroduced the bottom black gap on iOS Safari, and it stuck even after closing** (the toolbar stopped retracting on scroll).

**Cause:** #280's drawer-open scroll lock set `overflow: hidden` on `html`/`body`. On phones the **document is the scroller**, and toggling `overflow` on the *root* scroller is a known iOS Safari trap — it snaps the toolbar back to its expanded state and leaves the viewport stuck, so the gap reappears on open and persists after close.

**Fix:** remove the root overflow lock. It was never needed for background containment — the drawer's `overscroll-behavior: contain` plus the overlay's `touch-action: none` (both added in #280) keep touch scrolling out of the page **without touching the root scroller**, so the document stays scrollable and the toolbar keeps retracting normally through open/close.

```diff
-html:has(body.mobile-sidebar-toggle),
-body.mobile-sidebar-toggle { overflow: hidden; }
+/* deliberately NO root overflow lock — it makes iOS Safari's toolbar stick.
+   Containment = drawer overscroll-behavior:contain + overlay touch-action:none. */
```

## Verification (WebKit @ iPhone viewport)
- `html`/`body` overflow stays `visible` across the full **open → close** cycle (previously flipped to `hidden` on open — the trigger for the stuck toolbar)
- Document remains scrollable after the cycle (`scrollTop` advances)
- Tap-on-overlay still closes the drawer
- Header still opaque on open; theme toggle still beside the language selector (unchanged)

> As before, headless WebKit can't render the physical toolbar, so this is verified at the mechanism level (the root scroller's `overflow` is never toggled, which is what caused Safari to stick). Worth a final check on the iPhone — open/close the menu, then scroll, and the toolbar should retract as it does on navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)