### PR TITLE
mobile: iOS-safe menu — body scroll-lock, full-height drawer, matched language pill

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -94,6 +94,19 @@ body {
 	/* Keep scroll momentum inside the drawer instead of chaining to the page behind
 	   it (which made it hard to scroll the menu back up on iOS). */
 	overscroll-behavior: contain;
+	/* Fill the visible viewport with an explicit height instead of relying on the
+	   Tailwind `bottom-0` on this fixed drawer — iOS Safari can resolve that `bottom`
+	   short, leaving the drawer well above the bottom with a dark gap below it. A dvh
+	   height is viewport-relative and reliable. */
+	bottom: auto;
+	height: calc(100dvh - var(--theme-navbar-height));
+}
+
+/* Match the language pill's height to the sidebar's theme-toggle pill (38px) so the
+   two controls in the drawer footer row line up. */
+.or-drawer .lang-pill,
+.or-left .lang-pill {
+	height: 38px;
 }
 [dir='rtl'] .or-drawer { transform: translateX(100%); }
 body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); }


### PR DESCRIPTION
## Summary

Robust pass at the iOS Safari mobile-menu issues. Three changes:

### 1. iOS-safe body scroll lock (the key change)
The menu kept breaking iOS Safari's toolbar/full-height behavior even after CSS-only attempts (`overflow:hidden` on the root made the toolbar stick; removing it left the background loose). Switched to the **standard iOS modal scroll-lock** in `SidebarToggle.tsx`:
- On open: pin the page with `position: fixed; top: -scrollY` (the document is the scroller on phones).
- On close: clear it and `window.scrollTo(0, scrollY)`.

It never toggles `overflow` on the root scroller, and the explicit `scrollTo` on close **re-establishes the scroll context**, so Safari resumes hiding/showing its toolbar normally after the menu closes.

### 2. Drawer fills the full viewport height
The fixed drawer relied on Tailwind `bottom:0`, which iOS can resolve short (dark gap below the menu). Gave it an explicit `height: calc(100dvh - navbar)`.

### 3. Language pill matches the theme button
The language pill was `34px` vs the theme toggle's `38px`; matched it to `38px` in the drawer/sidebar footer row.

## Verification (WebKit @ iPhone viewport)
- Scroll lock: on open the document is non-scrollable and the body is pinned at the saved offset; on close the offset is restored and scrolling resumes
- Drawer height = viewport − navbar, reaches the bottom
- Language pill `38px` == theme toggle `38px`

> Caveat carried from prior rounds: there is no iOS Simulator on the build machine, so headless WebKit (no dynamic toolbar) can't fully confirm the on-device toolbar behavior. The scroll-lock is the battle-tested pattern for exactly this problem; needs a final confirmation on a physical iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)