### PR TITLE
mobile: display:none drawer & overlay when closed — fix stuck iOS Safari viewport gap

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -90,7 +90,13 @@ body {
 	padding: 14px 12px 0;
 	border-inline-end: 1px solid var(--or-border);
 	transform: translateX(-100%);
-	transition: transform 0.25s ease;
+	/* `display:none` when closed removes the drawer from the layout entirely. A
+	   persistent full-viewport position:fixed element makes iOS Safari pin its layout
+	   viewport to the toolbar-hidden height and never revert — which leaves a stuck black
+	   gap at the bottom (on scroll-up) after the menu has been opened once, until reload.
+	   `allow-discrete` keeps the slide animation while still ending at display:none. */
+	display: none;
+	transition: transform 0.25s ease, display 0.25s allow-discrete;
 	/* Keep scroll momentum inside the drawer instead of chaining to the page behind
 	   it (which made it hard to scroll the menu back up on iOS). */
 	overscroll-behavior: contain;
@@ -109,13 +115,20 @@ body {
 	height: 38px;
 }
 [dir='rtl'] .or-drawer { transform: translateX(100%); }
-body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); }
+body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); }
+/* Slide-in start state (for the display:none → block transition above). */
+@starting-style {
+	body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(-100%); }
+	[dir='rtl'] body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(100%); }
+}
 /* touch-action:none stops a drag on the overlay from scrolling the page behind the
    drawer. On phones the document is the scroller, where `overflow:hidden` is an
    unreliable lock on iOS Safari; this (plus the drawer's overscroll-behavior:contain)
    keeps the background fixed. Taps still fire, so tap-to-close keeps working. */
-#mobile-overlay { transition: opacity 0.25s ease; touch-action: none; }
-body.mobile-sidebar-toggle #mobile-overlay { opacity: 1 !important; pointer-events: auto !important; }
+/* display:none when closed (same reason as the drawer above) — keep the overlay out of
+   the layout so it can't pin iOS Safari's viewport once the menu has been used. */
+#mobile-overlay { display: none; transition: opacity 0.25s ease; touch-action: none; }
+body.mobile-sidebar-toggle #mobile-overlay { display: block; opacity: 1 !important; pointer-events: auto !important; }
 
 /* We deliberately do NOT lock the page scroll with `overflow:hidden` on html/body when
    the drawer opens. On phones the document is the scroller, and toggling overflow on the


### PR DESCRIPTION
## Summary

This targets the **actual** root cause of the persistent black gap, identified from your screen recording.

### What the recording showed
- Before opening the menu: scrolling retracts the toolbar, page fills, no gap (good).
- After opening **and closing** the menu: scrolling up brings back a solid **black band** at the bottom; scrolling down hides it; it persists until reload.

### Root cause
The drawer (`#mobile-left-sidebar`) and overlay (`#mobile-overlay`) are `position: fixed`, and when "closed" they stay in the layout (`opacity: 0` / translated off-screen). A persistent full-viewport fixed element makes **iOS Safari pin its layout viewport to the toolbar-hidden height and never revert**. Once the menu has been opened, the page is sized to that pinned height, so when the toolbar reappears (scroll-up) the page is too short for the visible area → black gap. Reload resets it.

Every earlier attempt (document-scroll model, removing the overflow lock, dvh drawer height) missed this because **the fixed elements never left the layout**.

### Fix
`display: none` the drawer and overlay when the menu is closed, so they're removed from the layout and iOS reverts its viewport. `transition: display 0.25s allow-discrete` + `@starting-style` keep the slide-in animation while still ending at `display: none`.

```css
.or-drawer { display: none; transition: transform .25s ease, display .25s allow-discrete; }
body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); }
@starting-style { body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(-100%); } }
#mobile-overlay { display: none; }
body.mobile-sidebar-toggle #mobile-overlay { display: block; }
```

## Verification (WebKit @ iPhone viewport)
- Closed (initial **and** after closing the menu): both compute `display: none` — no fixed full-viewport element left in the layout
- Open: both `display: block`; the drawer slide animation still plays (verified the transform animating mid-open)
- Round-trip open → close → both back to `display: none`

> Honest caveat (unchanged): there's no iOS Simulator on the build machine, so I can't watch the actual toolbar recover. But this directly removes the documented trigger (persistent fixed full-viewport elements) — verified that the elements leave the layout when closed, which is the specific thing that releases iOS's pinned viewport. This is the most direct fix for what the recording shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)