### PR TITLE
mobile: drawer fills behind the iOS toolbar + instant close (no delay)

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -96,16 +96,19 @@ body {
 	   gap at the bottom (on scroll-up) after the menu has been opened once, until reload.
 	   `allow-discrete` keeps the slide animation while still ending at display:none. */
 	display: none;
-	transition: transform 0.25s ease, display 0.25s allow-discrete;
 	/* Keep scroll momentum inside the drawer instead of chaining to the page behind
 	   it (which made it hard to scroll the menu back up on iOS). */
 	overscroll-behavior: contain;
-	/* Fill the visible viewport with an explicit height instead of relying on the
-	   Tailwind `bottom-0` on this fixed drawer — iOS Safari can resolve that `bottom`
-	   short, leaving the drawer well above the bottom with a dark gap below it. A dvh
-	   height is viewport-relative and reliable. */
+	/* Fill the FULL screen — including behind the iOS toolbar — so there's no dark band
+	   below the menu. `lvh` is the largest (toolbar-hidden) viewport; the translucent
+	   toolbar floats over the drawer's bottom and the long nav scrolls inside. Safe
+	   because the drawer is display:none when closed, so it can't pin the layout viewport.
+	   The open/close transition lives on the open-state rule below (not here) so closing
+	   is INSTANT — otherwise the drawer lingers ~0.25s before display:none, keeping iOS's
+	   viewport pinned and flashing the gap back (the "weird half-second delay"). */
 	bottom: auto;
-	height: calc(100dvh - var(--theme-navbar-height));
+	height: calc(100vh - var(--theme-navbar-height));
+	height: calc(100lvh - var(--theme-navbar-height));
 }
 
 /* Match the language pill's height to the sidebar's theme-toggle pill (38px) so the
@@ -115,7 +118,7 @@ body {
 	height: 38px;
 }
 [dir='rtl'] .or-drawer { transform: translateX(100%); }
-body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); }
+body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); transition: transform 0.25s ease, display 0.25s allow-discrete; }
 /* Slide-in start state (for the display:none → block transition above). */
 @starting-style {
 	body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(-100%); }
@@ -127,7 +130,7 @@ body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; tran
    keeps the background fixed. Taps still fire, so tap-to-close keeps working. */
 /* display:none when closed (same reason as the drawer above) — keep the overlay out of
    the layout so it can't pin iOS Safari's viewport once the menu has been used. */
-#mobile-overlay { display: none; transition: opacity 0.25s ease; touch-action: none; }
+#mobile-overlay { display: none; bottom: auto; height: 100vh; height: 100lvh; transition: opacity 0.25s ease; touch-action: none; }
 body.mobile-sidebar-toggle #mobile-overlay { display: block; opacity: 1 !important; pointer-events: auto !important; }
 
 /* We deliberately do NOT lock the page scroll with `overflow:hidden` on html/body when


### PR DESCRIPTION
## Summary

Follow-up to #283 (which fixed the persistent black box). The recording showed two things left:

### 1. Menu still not full height (dark band below the drawer)
At full resolution the drawer ends ~125px above the bottom with a black band (containing the Safari toolbar) below it. The drawer/overlay were sized to the **dynamic** viewport (`100dvh` = the toolbar-*shown* height), so they stop above the toolbar.

Fix: size them to the **large** viewport (`100lvh`, with `100vh` fallback) so they fill the full screen *behind* the translucent toolbar — no dark band. This is safe now because both are `display:none` when closed (#283), so a large fixed element can't pin the layout viewport.

### 2. ~0.5s delay when closing ("weird")
The drawer's exit used `transition: display 0.25s allow-discrete`, which keeps it in the layout for 0.25s before `display:none`. iOS only releases its pinned viewport (and clears the gap) once the element is gone — hence the delay.

Fix: move the transition to the **open-state** rule, so closing reverts to a no-transition default and is **instant**. The slide-in still animates (open-state transition + `@starting-style`).

```css
.or-drawer { display: none; height: calc(100lvh - var(--theme-navbar-height)); /* no transition here */ }
body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); transition: transform .25s ease, display .25s allow-discrete; }
#mobile-overlay { display: none; height: 100lvh; bottom: auto; }
```

## Verification (WebKit @ iPhone viewport)
- Slide-in still animates (mid-open transform captured)
- After close, drawer + overlay compute `display: none` within **~40ms** (was ~250ms) → no delay, and iOS's viewport releases immediately
- Heights resolve to the full viewport (on iOS, `lvh` extends behind the toolbar)

> Same standing caveat: no iOS Simulator on the build machine, so the behind-the-toolbar fill and the toolbar timing need your on-device check. But this directly addresses both things the recording showed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)