### PR TITLE
Update OpenReplay tracker to v18.0.17

### DIFF
--- a/src/layouts/HeadImports.astro
+++ b/src/layouts/HeadImports.astro
@@ -75,7 +75,7 @@ import { Tooltips } from 'astro-tooltips';
 			return false;
 		};
 		r.getSessionToken = function () {};
-	})('//static.openreplay.com/rc/openreplay-assist.js', 1, 0, initOpts, startOpts);
+	})('//static.openreplay.com/18.0.17/openreplay-assist.js', 1, 0, initOpts, startOpts);
 </script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## What

Pins the docs-site OpenReplay tracker script to **v18.0.17**.

In [`src/layouts/HeadImports.astro`](src/layouts/HeadImports.astro), the tracker loader URL changes from the `rc` channel to the pinned version:

```diff
-})('//static.openreplay.com/rc/openreplay-assist.js', 1, 0, initOpts, startOpts);
+})('//static.openreplay.com/18.0.17/openreplay-assist.js', 1, 0, initOpts, startOpts);
```

## Why

This is the OpenReplay tracker the documentation site itself runs (see the comment in `BaseLayout.astro`). Pinning it to a released version matches the established convention for this file (previously pinned to `18.0.8`, `17.0.0`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)