### PR TITLE
feat(seo): emit schema.org JSON-LD for AI/GEO discoverability

### DIFF
--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -52,7 +52,7 @@ const ogLocale = bcpLang.replace(/-/g, '_');
 <meta
 	name="description"
 	property="og:description"
-	content={content.description ? content.description : t('site.description')}
+	content={content.description || content.metaDescription || t('site.description')}
 />
 <meta property="og:site_name" content={t('site.title')} />
 
@@ -62,7 +62,7 @@ const ogLocale = bcpLang.replace(/-/g, '_');
 <meta name="twitter:title" content={content.title ?? t('site.title')} />
 <meta
 	name="twitter:description"
-	content={content.description ? content.description : t('site.description')}
+	content={content.description || content.metaDescription || t('site.description')}
 />
 <meta name="twitter:image" content={canonicalImageSrc} />
 <meta name="twitter:image:alt" content={imageAlt} />

--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -67,9 +67,4 @@ const ogLocale = bcpLang.replace(/-/g, '_');
 <meta name="twitter:image" content={canonicalImageSrc} />
 <meta name="twitter:image:alt" content={imageAlt} />
 
-<!--
-  TODO: Add json+ld data, maybe https://schema.org/APIReference makes sense?
-  Docs: https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data
-  https://www.npmjs.com/package/schema-dts seems like a great resource for implementing this.
-  Even better, there’s a React component that integrates with `schema-dts`: https://github.com/google/react-schemaorg
--->
+<!-- schema.org JSON-LD is emitted by ../components/SchemaOrg.astro (included in BaseLayout). -->

--- a/src/components/SchemaOrg.astro
+++ b/src/components/SchemaOrg.astro
@@ -1,0 +1,150 @@
+---
+/**
+ * Emits schema.org JSON-LD (as a single @graph) for AI/GEO discoverability and
+ * rich results. Every page carries the identity nodes (Organization, WebSite,
+ * SoftwareApplication) so a crawler that fetches a single page gets a complete,
+ * self-resolving entity graph; content (non-home) pages additionally carry a
+ * TechArticle and a BreadcrumbList.
+ *
+ * Deliberately omitted (do not add without a real data source):
+ *  - dateModified: no date exists in frontmatter — fabricating one is worse than none.
+ *  - SearchAction: docs search is a client-side Algolia modal, not a query-string
+ *    URL, so there is no honest urlTemplate to advertise.
+ */
+import { normalizeLangTag } from '../i18n/bcp-normalize';
+import languages from '../i18n/languages';
+import { useTranslations } from '../i18n/util';
+import { getLanguageFromURL } from '../util';
+import { getBreadcrumbTrail } from '../util/getBreadcrumb';
+import { getOgImageUrl } from '../util/getOgImageUrl';
+
+export interface Props {
+	content: any;
+	canonicalURL: URL;
+}
+
+const { content = {}, canonicalURL } = Astro.props;
+const t = useTranslations(Astro);
+const site = Astro.site!; // configured as https://docs.openreplay.com/
+const abs = (path: string) => new URL(path, site).href;
+
+const lang = getLanguageFromURL(canonicalURL.pathname || '/');
+const bcpLang = normalizeLangTag(lang);
+
+// Stable global identifiers (resolved against the OpenReplay product site).
+const ORG_ID = 'https://openreplay.com/#organization';
+const WEBSITE_ID = `${site.origin}/#website`;
+const SOFTWARE_ID = 'https://openreplay.com/#software';
+
+// Is this the (localized) docs homepage? Strip lang + optional version + trailing slash.
+const pageSlug = canonicalURL.pathname
+	.replace(/^\/[a-z-]{2,5}(\/v\d+\.\d+\.\d+)?\//, '')
+	.replace(/\/+$/, '');
+const isHome = pageSlug === '' || pageSlug === 'home';
+
+const organization = {
+	'@type': 'Organization',
+	'@id': ORG_ID,
+	name: 'OpenReplay',
+	url: 'https://openreplay.com',
+	logo: {
+		'@type': 'ImageObject',
+		url: abs('/android-chrome-512x512.png'),
+		width: 512,
+		height: 512,
+		caption: 'OpenReplay',
+	},
+	description:
+		'OpenReplay is an open-source session replay suite for developers — session replay, co-browsing, and product analytics, self-hosted or cloud.',
+	sameAs: [
+		'https://github.com/openreplay',
+		'https://www.linkedin.com/company/openreplay',
+		'https://x.com/OpenReplayHQ',
+		'https://www.youtube.com/@openreplay',
+	],
+};
+
+const website = {
+	'@type': 'WebSite',
+	'@id': WEBSITE_ID,
+	name: t('site.title'),
+	url: abs(`/${lang}/home/`),
+	publisher: { '@id': ORG_ID },
+	inLanguage: Object.keys(languages).map((l) => normalizeLangTag(l)),
+};
+
+const software = {
+	'@type': 'SoftwareApplication',
+	'@id': SOFTWARE_ID,
+	name: 'OpenReplay',
+	applicationCategory: 'DeveloperApplication',
+	operatingSystem: 'Web, Linux',
+	description:
+		'Open-source session replay suite: session replay, co-browsing, and product analytics. Self-hosted or cloud.',
+	url: 'https://openreplay.com',
+	downloadUrl: 'https://github.com/openreplay/openreplay',
+	softwareHelp: abs(`/${lang}/home/`),
+	license: 'https://github.com/openreplay/openreplay/blob/main/LICENSE',
+	// Free to self-host and on the free cloud tier. `offers` is intentionally
+	// omitted: a SoftwareApplication Offer is only rich-result-eligible alongside
+	// an aggregateRating, and we have no honest rating source to cite.
+	isAccessibleForFree: true,
+	publisher: { '@id': ORG_ID },
+};
+
+const graph: Record<string, unknown>[] = [organization, website, software];
+
+if (!isHome) {
+	const title = content.title ?? t('site.title');
+	const description = content.description || content.metaDescription || t('site.description');
+
+	const ogImageUrl = getOgImageUrl(canonicalURL.pathname, !!Astro.params.fallback);
+	const imageSrc = content?.image?.src ?? ogImageUrl ?? t('site.og.imageSrc');
+
+	// Build the breadcrumb trail; guarantee the current page is the final crumb
+	// even when it isn't present in the nav tree.
+	const trail = getBreadcrumbTrail(canonicalURL.pathname);
+	const stripSlash = (s: string) => s.replace(/\/+$/, '');
+	if (stripSlash(trail[trail.length - 1]?.path ?? '') !== stripSlash(canonicalURL.pathname)) {
+		trail.push({ name: title, path: canonicalURL.pathname });
+	}
+	// Top-level docs section (the crumb right after "Docs"), when the page isn't
+	// itself a top-level page. Free to derive from the trail.
+	const articleSection = trail.length > 2 ? trail[1].name : undefined;
+
+	graph.push({
+		'@type': 'TechArticle',
+		'@id': `${canonicalURL.href}#article`,
+		headline: title,
+		name: title,
+		description,
+		url: canonicalURL.href,
+		mainEntityOfPage: canonicalURL.href,
+		inLanguage: bcpLang,
+		...(articleSection ? { articleSection } : {}),
+		image: new URL(imageSrc, site).href,
+		isPartOf: { '@id': WEBSITE_ID },
+		author: { '@id': ORG_ID },
+		publisher: { '@id': ORG_ID },
+		about: { '@id': SOFTWARE_ID },
+		breadcrumb: { '@id': `${canonicalURL.href}#breadcrumb` },
+	});
+
+	graph.push({
+		'@type': 'BreadcrumbList',
+		'@id': `${canonicalURL.href}#breadcrumb`,
+		itemListElement: trail.map((c, i) => ({
+			'@type': 'ListItem',
+			position: i + 1,
+			name: c.name,
+			item: abs(c.path),
+		})),
+	});
+}
+
+const jsonLd = { '@context': 'https://schema.org', '@graph': graph };
+// Escape "<" so a value containing "</script>" can't break out of the tag.
+const serialized = JSON.stringify(jsonLd).replace(/</g, '\\u003c');
+---
+
+<script type="application/ld+json" is:inline set:html={serialized} />

--- a/src/i18n/es/ui.ts
+++ b/src/i18n/es/ui.ts
@@ -10,12 +10,11 @@ export default UIDictionary({
 	'aside.caution': 'Precaución',
 	'aside.danger': 'Peligro',
 	// Site settings
-	'site.title': 'Documentación de Astro',
+	'site.title': 'Documentación de OpenReplay',
 	'site.description':
-		'Construye páginas web más rápidas con menos Javascript en el lado del cliente.',
+		'Suite de session replay de código abierto, creada para desarrolladores.',
 	'site.og.imageSrc': '/default-og-image.png?v=1',
-	'site.og.imageAlt':
-		'Logo de Astro en el espacio estrellado, con un planeta púrpura parecido a Saturno flotando en el fondo a la derecha.',
+	'site.og.imageAlt': 'Suite de session replay de código abierto, creada para desarrolladores.',
 	// Left Sidebar
 	'leftSidebar.a11yTitle': 'Primario',
 	'leftSidebar.learnTab': 'Aprenda',

--- a/src/i18n/fr/ui.ts
+++ b/src/i18n/fr/ui.ts
@@ -4,12 +4,11 @@ export default UIDictionary({
 	'a11y.skipLink': 'Aller au contenu principal',
 	'navbar.a11yTitle': 'Navigation principale',
 	// Site settings
-	'site.title': 'Documentation Astro',
+	'site.title': 'Documentation OpenReplay',
 	'site.description':
-		'Compilez des sites plus rapidement avec moins de JavaScript pour vos utilisateurs.',
+		'Suite de session replay open source, conçue pour les développeurs.',
 	'site.og.imageSrc': '/default-og-image.png?v=1',
-	'site.og.imageAlt':
-		"Logo d'Astro dans l'espace, avec une planète violette dans le style de saturne flottant à droite de l'image.",
+	'site.og.imageAlt': 'Suite de session replay open source, conçue pour les développeurs.',
 	// Left Sidebar
 	'leftSidebar.a11yTitle': 'Navigation du site',
 	'leftSidebar.learnTab': 'Apprendre',

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import Header from '../components/Header/Header.astro';
 import HeadCommon from '../components/HeadCommon.astro';
 import HeadSEO from '../components/HeadSEO.astro';
+import SchemaOrg from '../components/SchemaOrg.astro';
 import LeftSidebar from '../components/LeftSidebar/LeftSidebar.astro';
 import Hero from '../components/Hero.astro';
 import { normalizeLangTag } from '../i18n/bcp-normalize';
@@ -42,6 +43,7 @@ const breadcrumb = getBreadcrumb(currentPage);
 	<head>
 		<HeadCommon />
 		<HeadSEO {content} {canonicalURL} site={Astro.site} />
+		<SchemaOrg {content} {canonicalURL} />
 		<title set:html={formatTitle(content)}></title>
 		<!-- Following import contains openreplay Tracker, fonts used in Docs -->
 		<HeadImports />

--- a/src/util/getBreadcrumb.ts
+++ b/src/util/getBreadcrumb.ts
@@ -41,3 +41,51 @@ export function getBreadcrumb(pathname: string): string[] {
 	walk(nav.children, []);
 	return ['Docs', ...chain];
 }
+
+export interface Crumb {
+	name: string;
+	/** Locale- (and version-) aware absolute path, e.g. "/en/deployment/deploy-aws/". */
+	path: string;
+}
+
+/**
+ * Like {@link getBreadcrumb}, but returns each crumb's label *and* a navigable
+ * path (for structured data such as schema.org BreadcrumbList). The trail always
+ * starts at the localized docs home and mirrors the visible breadcrumb labels.
+ */
+export function getBreadcrumbTrail(pathname: string): Crumb[] {
+	const lang = getLanguageFromURL(pathname) || 'en';
+	const version = getVersionFromURL(pathname);
+	const versionSeg = version ? `/v${version}` : '';
+	const toPath = (slug: string) => `/${lang}${versionSeg}/${norm(slug)}/`;
+
+	let slug = removeTrailingSlash(removeLeadingSlash(pathname));
+	slug = slug.replace(new RegExp(`^${lang}(/|$)`), '');
+	if (version) slug = slug.replace(`v${version}/`, '');
+	const target = norm(slug);
+
+	const nav = localizeNav(lang);
+	const chain: Crumb[] = [];
+
+	const walk = (items: NavItem[] | undefined, acc: Crumb[]): boolean => {
+		if (!items) return false;
+		for (const it of items) {
+			if (it.isSectionTitle) continue;
+			const label = typeof it.text === 'string' ? it.text : String(it.text);
+			const crumb: Crumb | null = it.slug != null ? { name: label, path: toPath(it.slug) } : null;
+			if (it.slug != null && norm(it.slug) === target) {
+				chain.push(...acc, crumb!);
+				return true;
+			}
+			if (it.children && it.children.length) {
+				const nextAcc = crumb ? [...acc, crumb] : acc;
+				if (walk(it.children, nextAcc)) return true;
+			}
+		}
+		return false;
+	};
+
+	walk(nav.children, []);
+	// Root crumb is version-aware so a versioned page's trail stays internally consistent.
+	return [{ name: 'Docs', path: `/${lang}${versionSeg}/home/` }, ...chain];
+}


### PR DESCRIPTION
## What & why

A GEO audit of docs.openreplay.com found **zero structured data on the entire site** — its single biggest AI-discoverability gap (Schema score 3/100). This adds schema.org JSON-LD so AI engines (ChatGPT, Claude, Perplexity, Gemini, Google AI Overviews) and search engines can resolve OpenReplay as an entity and cite individual doc pages.

One `@graph` is emitted per page from the shared `BaseLayout`, so **every** crawled URL carries a complete, self-resolving entity graph:

| Scope | Nodes |
|---|---|
| Every page | `Organization` (with verified `sameAs` → GitHub, LinkedIn, X, YouTube), `WebSite`, `SoftwareApplication` |
| Content pages | `TechArticle` (`about`→software, `author`/`publisher`→org, `isPartOf`→website) + `BreadcrumbList` |

## Changes

- **`src/components/SchemaOrg.astro`** (new) — builds the graph, emits `<script type="application/ld+json">` (with `<` escaped to prevent `</script>` breakout).
- **`src/util/getBreadcrumb.ts`** — new `getBreadcrumbTrail()` returns breadcrumb labels **+ URLs** (locale- and version-aware), mirroring the existing visible breadcrumb labels for Google's consistency requirement.
- **`src/layouts/BaseLayout.astro`** — wires `<SchemaOrg>` into `<head>`.
- **`src/components/HeadSEO.astro`** — replaced the stale "add JSON-LD" TODO with a pointer.
- **`src/i18n/es/ui.ts`, `src/i18n/fr/ui.ts`** — fix leftover Astro-starter strings (`site.title`/`description`/`og.imageAlt`). Without this, the new `WebSite.name` identity node and OG tags would publish *"Documentación de Astro"* / *"Documentation Astro"* as the canonical brand name.

## Deliberate omissions (no honest data source — intentionally not added)

- **`dateModified`** — no date field exists in frontmatter; fabricating one is worse than none.
- **`SearchAction`** — docs search is a client-side Algolia modal, not a query-string URL.
- **`offers`** on `SoftwareApplication` — a SoftwareApplication Offer is only rich-result-eligible alongside an `aggregateRating`, and there's no honest rating source; `isAccessibleForFree: true` conveys the free tier without triggering a validator error.

Descriptions use the real per-page **`metaDescription`** frontmatter rather than the generic site fallback.

## Verification

- JSON-LD renders **valid JSON** across home / content / `es` / `fr` / `ar-ae` (RTL) / versioned / not-in-nav pages (verified via dev SSR — the same render path the build uses).
- Reviewed by a 5-dimension adversarial pass (schema.org correctness, Astro/build-safety, i18n/versioning, GEO efficacy, claim accuracy) with per-finding self-verification — **no confirmed critical/high issues**; all medium findings folded in.
- ⚠️ A full local `astro build` was **memory-bound** (this machine has 16GB; the build config requires 30GB — CI provisions that + swap). It compiled all pages and entered page generation before the local OOM, which is a hardware ceiling, not a code error. CI is provisioned for this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)