### PR TITLE
fix(theme): stray separator above first heading + heading text clipping

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -244,6 +244,11 @@ h5 {
 	        margin-inline-end: calc(-1 * var(--icon-size-x));
 	width: var(--icon-size-x);
 	height: var(--icon-size-y);
+	/* Keep the anchor at its full gutter width. Without this, a heading long
+	   enough to wrap makes flex shrink the anchor, narrowing the negative-margin
+	   gutter and pulling the heading text left into article.content's
+	   overflow-x:hidden clip (the first letter gets cut off). */
+	flex-shrink: 0;
 	text-decoration: none;
 	-webkit-box-pack: center;
 	    -ms-flex-pack: center;

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -359,7 +359,14 @@ body.mobile-sidebar-toggle header {
 	border-top: 1px solid var(--border-soft);
 	scroll-margin-top: 80px;
 }
-.content .heading-wrapper.level-h2:first-child { margin-top: 0; border-top: 0; padding-top: 0; }
+/* No separator above the first section heading. The article <header> and any
+   intro <p> always precede the first h2, so the old :first-child reset never
+   matched and a stray rule showed under the title — worst on pages with no intro
+   text. Target the first level-h2 (the one not preceded by another level-h2). */
+.content .heading-wrapper.level-h2:not(.heading-wrapper.level-h2 ~ .heading-wrapper.level-h2) {
+	border-top: 0;
+	padding-top: 0;
+}
 .content h3,
 .content .heading-wrapper.level-h3 > h3 {
 	font-family: var(--fd);


### PR DESCRIPTION
## What

Two small CSS fixes to the docs theme. Both live in the shared global stylesheets (`public/redesign.css`, `public/index.css`), so they apply to every page, locale (es/fr/ru/zh/ar-ae), and version automatically.

### 1. Remove the stray separator above the first section heading

`.heading-wrapper.level-h2` draws a `border-top` separator before each section. The first one was meant to be suppressed by a `:first-child` reset, but the article `<header>` (and any intro `<p>`) always precede the first `h2`, so that reset never matched — leaving a stray rule floating under the page title. It looked especially odd on pages with no intro text above the first heading.

Replaced the dead `:first-child` rule with one that targets the first `level-h2` (the one not preceded by another `level-h2`), regardless of the header/intro before it. Subsequent section separators are unchanged.

### 2. Stop the first letters of long headings being clipped

The heading anchor-link (hover ¶ icon) sits in a 32px negative-margin gutter and is what keeps heading text aligned to the content-column edge. It had the default `flex-shrink: 1`, so a heading long enough to **wrap to 2+ lines** let flexbox shrink the anchor below 32px, narrowing the gutter and pushing the heading text left into `article.content`'s `overflow-x: hidden` clip — cutting off the first letter of each line.

Added `flex-shrink: 0` so the anchor always keeps its full width.

## Testing

Verified on the local dev server via computed styles + screenshots:

- **First heading**: separator removed; subsequent section separators kept.
- **Home page** (`body.or-home-page`): still zero separators — no regression.
- **Long wrapping heading** (`/en/configuration/proxy-settings`): heading text now starts at the content edge (302px), 0px clipped; previously shifted 8px into the overflow clip.
- **Mobile**: the row-reverse flex layout is gated behind `@media (min-width: 50em)`, so `flex-shrink: 0` is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
