### PR TITLE
mobile: fix iOS 26 Safari clipping the menu short + set Cache-Control on deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,15 @@ on:
   push:
     branches: [main]
 
+# Serialize deploys: at most one run touches S3 at a time. While one runs, only the
+# LATEST queued push waits (GitHub auto-supersedes older pending runs in the group).
+# cancel-in-progress must stay FALSE: cancelling a run mid "aws s3 sync" kills the
+# upload partway and leaves the live bucket half old / half new for the ~25 min the
+# next run needs to build. A deploy that started always finishes; the queued run
+# then brings the site to the newest commit.
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_CONTENT_ACCESS_ID }}
@@ -25,6 +31,9 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest-l
+    # Deploys take ~25-28 min; bound a hung run so it can't hold the concurrency
+    # queue for the 6h default and stall every subsequent deploy behind it.
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,8 +50,41 @@ jobs:
           echo "::error::Build looks truncated ($count HTML files < 5000); aborting before --delete sync."
           exit 1
         fi
-    # --delete keeps the bucket in exact sync with the build output, so pages removed
-    # from source (e.g. retired pre-v1.17.0 versions) are also removed from S3.
-    - run: aws s3 sync ./dist/ s3://openreplay-documentation --acl public-read --exact-timestamps --delete
+    # The sync is split into tiered passes so every object gets an explicit
+    # Cache-Control header. Objects used to ship with NO Cache-Control, so browsers
+    # cached them heuristically — iOS Safari served stale /redesign.css for days after
+    # deploys, masking fixes (see the mobile-drawer saga, PRs #278-#284).
+    # Pass order matters: hashed assets go up before the HTML that references them,
+    # so a page served mid-deploy never points at a missing asset.
+    # (--exact-timestamps was dropped from the old command: the AWS CLI only honors
+    # it for S3->local downloads, so it was a no-op here — aws/aws-cli#4460.)
+    - name: Sync hashed assets (cache 1 year, immutable)
+      run: >
+        aws s3 sync ./dist/ s3://openreplay-documentation
+        --exclude "*" --include "_astro/*"
+        --cache-control "public, max-age=31536000, immutable"
+        --acl public-read
+    - name: Sync unhashed static assets (cache 5 min)
+      run: >
+        aws s3 sync ./dist/ s3://openreplay-documentation
+        --exclude "_astro/*" --exclude "*.html"
+        --cache-control "public, max-age=300, must-revalidate"
+        --acl public-read
+    - name: Sync HTML (always revalidate)
+      run: >
+        aws s3 sync ./dist/ s3://openreplay-documentation
+        --exclude "*" --include "*.html"
+        --cache-control "public, max-age=0, must-revalidate"
+        --acl public-read
+    # Deletions run as a separate, UNFILTERED pass: mixing --delete with
+    # --exclude/--include has subtle semantics in the AWS CLI (aws-cli#1268, #4923),
+    # and a filtered delete that went wrong could wipe live objects outside its tier.
+    # --size-only makes this pass provably upload-nothing (every object was just
+    # synced above with identical sizes, so it can't re-upload and strip the
+    # Cache-Control set by the passes above, even under runner clock skew); it only
+    # removes objects that no longer exist in the build, exactly like the old single
+    # sync did (e.g. retired pre-v1.17.0 versions).
+    - name: Remove deleted pages from S3
+      run: aws s3 sync ./dist/ s3://openreplay-documentation --acl public-read --size-only --delete
     - run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID}} --paths "/*"
 

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -99,16 +99,22 @@ body {
 	/* Keep scroll momentum inside the drawer instead of chaining to the page behind
 	   it (which made it hard to scroll the menu back up on iOS). */
 	overscroll-behavior: contain;
-	/* Fill the FULL screen — including behind the iOS toolbar — so there's no dark band
-	   below the menu. `lvh` is the largest (toolbar-hidden) viewport; the translucent
-	   toolbar floats over the drawer's bottom and the long nav scrolls inside. Safe
-	   because the drawer is display:none when closed, so it can't pin the layout viewport.
+	/* Height comes from inset anchoring — the markup's `top-14 bottom-0` — and NOT from
+	   an explicit viewport-unit height. iOS 26 Safari (Liquid Glass) CLIPS fixed content
+	   that extends past the layout-viewport bottom instead of painting it behind the
+	   toolbar, so the previous `height: calc(100lvh - navbar)` lost its bottom slice
+	   whenever the toolbar was expanded: menu visibly cut short, dark band below it
+	   (Safari's own chrome-tint fill). Fixed upstream in Safari 26.1
+	   (webkit.org/blog/17541, "bottom gap ... viewport-sized fixed containers"), but
+	   26.0 devices remain. An lvh height was also broken on OLDER iOS: the bottom
+	   toolbar-slice of the drawer's own scrollport sat offscreen and a scroll container
+	   can't reveal its own offscreen portion, so the last nav items were unreachable.
+	   A top+bottom-anchored fixed element tracks the layout viewport in BOTH toolbar
+	   states on every iOS version (same pattern as Starlight/Docusaurus/shadcn).
+	   Do NOT add height/min-height in vh/lvh/dvh units here.
 	   The open/close transition lives on the open-state rule below (not here) so closing
 	   is INSTANT — otherwise the drawer lingers ~0.25s before display:none, keeping iOS's
 	   viewport pinned and flashing the gap back (the "weird half-second delay"). */
-	bottom: auto;
-	height: calc(100vh - var(--theme-navbar-height));
-	height: calc(100lvh - var(--theme-navbar-height));
 }
 
 /* Match the language pill's height to the sidebar's theme-toggle pill (38px) so the
@@ -118,7 +124,8 @@ body {
 	height: 38px;
 }
 [dir='rtl'] .or-drawer { transform: translateX(100%); }
-body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); transition: transform 0.25s ease, display 0.25s allow-discrete; }
+/* Second box-shadow = paint-only bleed below the drawer (same reason as #mobile-overlay). */
+body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3), 0 120px 0 0 var(--page); transition: transform 0.25s ease, display 0.25s allow-discrete; }
 /* Slide-in start state (for the display:none → block transition above). */
 @starting-style {
 	body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(-100%); }
@@ -129,9 +136,15 @@ body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; tran
    unreliable lock on iOS Safari; this (plus the drawer's overscroll-behavior:contain)
    keeps the background fixed. Taps still fire, so tap-to-close keeps working. */
 /* display:none when closed (same reason as the drawer above) — keep the overlay out of
-   the layout so it can't pin iOS Safari's viewport once the menu has been used. */
-#mobile-overlay { display: none; bottom: auto; height: 100vh; height: 100lvh; transition: opacity 0.25s ease; touch-action: none; }
-body.mobile-sidebar-toggle #mobile-overlay { display: block; opacity: 1 !important; pointer-events: auto !important; }
+   the layout so it can't pin iOS Safari's viewport once the menu has been used.
+   Sized by the markup's `inset-0` (inset anchoring, not viewport units) for the same
+   iOS 26 clipping reason as the drawer above. The box-shadow is a PAINT-ONLY bleed:
+   on pre-26 iOS the layout viewport ends at the expanded toolbar's top edge, and the
+   translucent toolbar would otherwise show the un-dimmed page through its glass — the
+   solid downward shadow paints the overlay's black into that strip without affecting
+   layout. Never turn this into a height/min-height (see the drawer note above). */
+#mobile-overlay { display: none; touch-action: none; box-shadow: 0 120px 0 0 rgb(0 0 0 / 0.9); }
+body.mobile-sidebar-toggle #mobile-overlay { display: block; }
 
 /* We deliberately do NOT lock the page scroll with `overflow:hidden` on html/body when
    the drawer opens. On phones the document is the scroller, and toggling overflow on the

--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -1,6 +1,7 @@
 ---
 import '@fontsource/ibm-plex-mono/400.css';
 import '@fontsource/ibm-plex-mono/400-italic.css';
+import { cssVersions } from '../util/cssVersions';
 ---
 
 <!-- Global Metadata -->
@@ -12,10 +13,12 @@ import '@fontsource/ibm-plex-mono/400-italic.css';
 <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="sitemap" href="/sitemap-index.xml" />
 
-<!-- Global CSS -->
-<link rel="stylesheet" href="/theme.css" />
-<link rel="stylesheet" href="/index.css" />
-<link rel="stylesheet" href="/redesign.css" />
+<!-- Global CSS (content-hash ?v= busts browser caches the moment a file changes;
+     deploy.yml serves these with a 5-minute max-age, so the hash also guarantees a
+     fresh page never renders with mismatched, still-cached CSS) -->
+<link rel="stylesheet" href={`/theme.css?v=${cssVersions.theme}`} />
+<link rel="stylesheet" href={`/index.css?v=${cssVersions.index}`} />
+<link rel="stylesheet" href={`/redesign.css?v=${cssVersions.redesign}`} />
 
 <!-- Scrollable a11y code helper -->
 <script type="module" src="/make-scrollable-code-focusable.js"></script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -60,10 +60,11 @@ const breadcrumb = getBreadcrumb(currentPage);
 			<LeftSidebar {currentPage} />
 		</aside>
 
-		{/* Mobile Background Overlay */}
+		{/* Mobile Background Overlay (open/closed styling lives in redesign.css —
+		    display:none when closed, so no opacity/pointer-events utilities needed) */}
 		<div
 			id="mobile-overlay"
-			class="md:hidden fixed inset-0 bg-black bg-opacity-90 opacity-0 pointer-events-none transition-opacity duration-300 z-40"
+			class="md:hidden fixed inset-0 bg-black bg-opacity-90 z-40"
 			onclick="closeMobileMenu()"
 		></div>
 

--- a/src/util/cssVersions.ts
+++ b/src/util/cssVersions.ts
@@ -1,0 +1,32 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Content-hash version tokens for the global stylesheets in /public, appended
+ * as `?v=` by HeadCommon.astro. deploy.yml serves these files with a 5-minute
+ * max-age (they used to ship with NO Cache-Control header, and iOS Safari's
+ * heuristic caching served stale /redesign.css for days after deploys); the
+ * hash makes CSS changes propagate the moment the page HTML does, instead of
+ * after the TTL. Hashing file contents (rather than stamping the build time)
+ * busts a file's cache only when its bytes actually change, and keeps builds
+ * of identical source byte-identical.
+ */
+const version = (file: string): string => {
+	try {
+		return createHash('md5')
+			.update(readFileSync(resolve(process.cwd(), 'public', file)))
+			.digest('hex')
+			.slice(0, 8);
+	} catch {
+		// Unexpected cwd (file not found): fall back to a per-build stamp —
+		// busts more than needed, but never serves stale CSS.
+		return Date.now().toString(36);
+	}
+};
+
+export const cssVersions = {
+	theme: version('theme.css'),
+	index: version('index.css'),
+	redesign: version('redesign.css'),
+};


### PR DESCRIPTION
## What

Fixes the long-standing "menu opens but not to full screen height" bug on iOS Safari (Chrome iOS unaffected), and fixes the deploy pipeline so shipped fixes actually reach returning Safari visitors.

| Before (iOS Safari) | Root cause |
|---|---|
| Drawer stops ~1 toolbar-height short of the screen bottom with a dark band below it | iOS 26 (Liquid Glass) **clips** `position:fixed` content that extends past the layout-viewport bottom instead of painting it behind the toolbar like every earlier iOS. The drawer's `height: calc(100lvh − navbar)` overhangs that boundary whenever the toolbar is expanded, so Safari cuts off its bottom slice — the dark band is Safari's own chrome-tint fill. Apple fixed the worst case in Safari 26.1 ([release notes](https://webkit.org/blog/17541/webkit-features-for-safari-26-1/): "Fixed a bottom gap appearing on layouts with viewport-sized fixed containers on iOS"), but 26.0.x devices remain. |

The `lvh` sizing also had a hidden defect on *all* iOS versions: the bottom toolbar-slice of the drawer's own scrollport was unreachable (a scroll container can't reveal its own offscreen portion), so the last nav items could never scroll fully into view.

## How

**Drawer geometry** ([public/redesign.css](../blob/claude/ios-safari-menu-height-c25356/public/redesign.css))
- Drawer and overlay are now sized purely by **inset anchoring** (`top-14 bottom-0` / `inset-0`) — no `vh`/`lvh`/`dvh` heights. This is the pattern Astro Starlight, Docusaurus, and shadcn ship; it tracks the layout viewport in both toolbar states on every iOS version and can never overhang the clip region.
- Paint-only `box-shadow` bleeds below both elements keep the strip behind pre-iOS-26's translucent toolbar looking right, without touching the scrollport.
- Removed the overlay's inert `opacity-0 pointer-events-none transition-opacity` utilities and the `!important`s that existed only to out-shout them.
- All hard-won invariants from #278–#284 are preserved and documented in comments (display:none when closed, instant close, no root scroll lock, document-level phone scrolling, RTL slide-in).

**Cache propagation** (why fixes kept "not showing up" on iPhones)
- The global stylesheets ship from S3 with **no Cache-Control header**, so iOS Safari heuristically cached stale CSS for days after deploys. The three `<link>`s now carry a per-file content-hash `?v=` ([src/util/cssVersions.ts](../blob/claude/ios-safari-menu-height-c25356/src/util/cssVersions.ts)) — busts exactly when a file's bytes change, keeps identical builds byte-identical.
- [deploy.yml](../blob/claude/ios-safari-menu-height-c25356/.github/workflows/deploy.yml) now sets tiered Cache-Control: `/_astro/*` immutable 1 year; unhashed static assets 5 min; HTML always-revalidate. Deletions run on a final **unfiltered** `--size-only --delete` pass — combining `--delete` with `--include/--exclude` filters is a known aws-cli minefield ([#1268](https://github.com/aws/aws-cli/issues/1268), [#4923](https://github.com/aws/aws-cli/issues/4923)), and `--size-only` makes the pass provably upload-nothing so it can't strip the just-set headers. `--exact-timestamps` dropped (download-direction only, [#4460](https://github.com/aws/aws-cli/issues/4460)); `--acl public-read` kept (bucket relies on object ACLs).

- The workflow's concurrency group now uses `cancel-in-progress: false` (+ `timeout-minutes: 60`): previously a new push to main killed the running deploy — potentially mid `aws s3 sync`, leaving the bucket half old / half new for the ~25 min the next build takes. Deploys now always finish; GitHub queues only the latest push.

## Verified

- Chromium at iPhone viewport (375×812): drawer spans 56→812 exactly, scrolls to its last item fully in view, opens via hamburger with slide-in intact, closes instantly (display:none ≤1ms), overlay covers the full viewport, dark-mode bleed color correct, desktop shell untouched.
- Root cause and fix pattern verified against primary sources (WebKit release notes, WebKit Bugzilla #297779, Apple dev forums, MUI/Discourse iOS 26 issues) with an adversarial fact-check pass.
- deploy.yml YAML validated; sync filter semantics (`*` matches across `/`, first-deploy full re-upload, delete-pass upload-nothing guarantee) verified against AWS CLI docs and the CLI's filter implementation.

## Reviewer notes

- I couldn't drive real iOS Safari from this environment — after deploy, please check on an iPhone **in a private tab** (cached CSS from before this PR can otherwise mask the fix; that staleness is exactly what the caching half of this PR eliminates going forward).
- First deploy after merge re-uploads all objects (fresh build mtimes), applying headers in one shot — same sync duration as today.
- The 5-minute TTL on unhashed CSS is safe alongside the `?v=` hash: a fresh HTML page always references the hash of the CSS it was built with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
