### PR TITLE
Mobile sticky 'On this page' dropdown + note-callout icon fix

### DIFF
--- a/docs/superpowers/plans/2026-07-15-mobile-toc-dropdown.md
+++ b/docs/superpowers/plans/2026-07-15-mobile-toc-dropdown.md
@@ -1,0 +1,378 @@
+# Mobile Sticky "On This Page" Dropdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** At ≤1024px, revive the hidden mobile TOC as a redesign-styled sticky dropdown bar ("On this page ▸ ‹current section›") that pins below the header on scroll.
+
+**Architecture:** Reuse the existing `<details>`-based mobile mode of `TableOfContents.tsx` (approach A from the spec, `docs/superpowers/specs/2026-07-15-mobile-toc-dropdown-design.md`). Fix its scroll-spy for the phone document-scroll regime, replace redesign.css's kill rule with new bar/panel styling, and align the hydration breakpoint. No new components; no markup changes.
+
+**Tech Stack:** Astro 2 + Preact islands, plain CSS in `public/redesign.css` (loads after `index.css`; component CSS wins by specificity, not order).
+
+**Verification:** No JS test infra exists in this repo (no vitest/jest). Each task verifies via the running dev server (`http://localhost:4399`, tab `seed` in the Browser pane) + dev-server logs. Final task is a full behavioral sweep.
+
+**Facts you need (verified):**
+- `--theme-navbar-height: 56px` (public/theme.css:296), header is `position: fixed`.
+- Phones (<768px): the **document** scrolls (redesign.css:61–64). Tablets/desktop: `#or-main-scroll` scrolls.
+- Redesign tokens: `--page`, `--or-border`, `--text`, `--text-2`, `--text-3`, `--accent`, `--fb` (font). There is **no** `--text-1`.
+- `.or-toc-list` / `.or-toclink` / `.tick` styles (redesign.css:289–323) are unscoped → the mobile panel inherits the desktop TOC list look for free.
+- `html { scroll-padding-top: calc(1.5rem + navbar + 4rem) }` (index.css:975) already reserves mobile-bar space on the document scroller; heading wrappers carry `scroll-margin-top: 80px` (redesign.css:373,390). Phone jumps clear ≥144px, tablet jumps clear 80px > bar (44px + 8px offset + 6px gap). **No scroll-margin changes needed** — Task 5 verifies this empirically; a contingency rule is included there.
+- i18n label `rightSidebar.onThisPage` exists for all locales (src/i18n/*/ui.ts).
+- iOS 26 invariant (redesign.css drawer comments): pinned/fixed UI must never size past the layout viewport → panel max-height uses **svh only**.
+
+---
+
+### Task 0: Commit the pending blockquote-icon fix (unrelated working-tree change)
+
+The working tree has an uncommitted one-property fix in `public/redesign.css` (`padding: 0` on `.content blockquote::before` + comment). Commit it FIRST so feature commits stay clean.
+
+**Files:**
+- Modify: none (already edited)
+
+- [ ] **Step 0.1: Verify the diff is only the blockquote fix**
+
+Run: `git diff --stat`
+Expected: only `public/redesign.css` (≈5 insertions), plus untracked plan file.
+
+- [ ] **Step 0.2: Commit**
+
+```bash
+git add public/redesign.css
+git commit -m "fix(theme): stop note-callout icon bleeding into the Note: label
+
+The blockquote ::before inherited padding:0.1rem 1rem from index.css,
+inflating its box to 50px; mask:center/contain then re-centred the icon
+into the label text. Reset padding on the redesign rule.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Also commit this plan file:
+
+```bash
+git add docs/superpowers/plans/2026-07-15-mobile-toc-dropdown.md
+git commit -m "docs: add implementation plan for mobile TOC dropdown
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 1: Fix scroll-spy for the phone (document-scroll) regime
+
+**Files:**
+- Modify: `src/components/RightSidebar/TableOfContents.tsx:47-88` (the first `useEffect`)
+
+Today the spy always binds `#or-main-scroll`. On phones that element exists but is not the scroller, so the spy never fires and the bottom-of-page guard reads a `scrollTop` that is always 0. Bind both potential scrollers (only the real one emits events), resolve the regime per update via the same media query redesign.css uses, and use `document.scrollingElement` for the bottom guard in the document regime.
+
+- [ ] **Step 1.1: Replace the effect body**
+
+Replace the entire first `useEffect(() => { ... }, [headings.map((h) => h.slug).join('|')]);` (lines 47–88) with:
+
+```tsx
+	useEffect(() => {
+		// Position-based scroll-spy. Two scroll regimes (see redesign.css "APP SHELL"):
+		// phones (<768px) scroll the DOCUMENT; wider screens scroll #or-main-scroll.
+		// Bind both — only the real scroller emits scroll events — and resolve the
+		// active regime on every update so resizing across the breakpoint just works.
+		// An IntersectionObserver top-zone can never activate the LAST heading
+		// (nothing below it pushes it into the zone), so we pick the last heading
+		// above an activation line and add an explicit "scrolled to bottom" guard.
+		const phoneMQ = window.matchMedia('(max-width: 767.98px)');
+		const innerScroller = document.getElementById('or-main-scroll');
+		const headingEls = () =>
+			headings
+				.map(({ slug }) => document.getElementById(slug))
+				.filter((el): el is HTMLElement => !!el);
+
+		const update = () => {
+			const els = headingEls();
+			if (!els.length) return;
+			const scroller = phoneMQ.matches ? null : innerScroller;
+			// Document regime: the line is viewport-anchored (top = 0). Inner regime:
+			// anchored to the scroller's top edge, as before.
+			const top = scroller ? scroller.getBoundingClientRect().top : 0;
+			const line = top + 120; // activation line ~120px below the scroll area's top
+			let cur = els[0].id;
+			for (const el of els) {
+				if (el.getBoundingClientRect().top <= line) cur = el.id;
+			}
+			// At (or near) the bottom, the last section is the active one.
+			const sc = scroller ?? (document.scrollingElement as HTMLElement | null);
+			if (sc && sc.scrollHeight - sc.scrollTop - sc.clientHeight < 8) {
+				cur = els[els.length - 1].id;
+			}
+			setCurrentID(cur);
+		};
+
+		window.addEventListener('scroll', update, { passive: true });
+		innerScroller?.addEventListener('scroll', update, { passive: true });
+		window.addEventListener('resize', update);
+		update();
+
+		return () => {
+			window.removeEventListener('scroll', update);
+			innerScroller?.removeEventListener('scroll', update);
+			window.removeEventListener('resize', update);
+		};
+	}, [headings.map((h) => h.slug).join('|')]);
+```
+
+- [ ] **Step 1.2: Verify the dev server recompiles cleanly**
+
+Check dev-server output (Browser-pane `preview_logs`, level `error`).
+Expected: no TypeScript/compile errors mentioning `TableOfContents`.
+
+- [ ] **Step 1.3: Verify desktop TOC still spies correctly (regression check)**
+
+Browser pane at ≥1280px width on `/en/deployment/deploy-aws`: scroll the article; the right-sidebar TOC active item must follow the sections (this instance uses the inner-scroller regime — unchanged behavior).
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add src/components/RightSidebar/TableOfContents.tsx
+git commit -m "fix(toc): make scroll-spy work in the phone document-scroll regime
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Style the sticky bar + dropdown panel in redesign.css
+
+**Files:**
+- Modify: `public/redesign.css:174-175` (the kill rule)
+
+- [ ] **Step 2.1: Replace the kill rule with the mobile-bar block**
+
+Replace:
+
+```css
+/* hide the legacy mobile TOC bar — design hides TOC on small screens */
+.fixed-mobile-bar { display: none !important; }
+```
+
+with:
+
+```css
+/* ===================== MOBILE "ON THIS PAGE" BAR ===================== */
+/* Shown wherever the right-hand TOC is hidden (≤1024px, next block). In-flow at the
+   top of the article, pins on scroll (position:sticky). Phones pin below the fixed
+   header (the DOCUMENT scrolls there); tablets pin at the top of the inner
+   #or-main-scroll scroller (which already starts below the header).
+   Bar height lives in --or-mobile-toc-h so any future offset rules share one source.
+   The dropdown panel's max-height uses svh ONLY — never vh/lvh/dvh — per the iOS 26
+   layout-viewport clipping notes on .or-drawer above.
+   Selectors are ≥(0,2,0) on purpose: the component's legacy TableOfContents.css is
+   bundled into <style> tags whose order vs this file is not guaranteed, so we win on
+   specificity, not order. */
+:root { --or-mobile-toc-h: 44px; }
+
+.fixed-mobile-bar { display: none; }
+
+@media (max-width: 1024px) {
+	.fixed-mobile-bar {
+		display: block;
+		position: sticky;
+		top: 8px; /* tablet: #or-main-scroll's top edge is already below the header */
+		z-index: 10;
+		margin-bottom: 18px;
+	}
+	.fixed-mobile-bar .toc-mobile-container {
+		display: block;
+		position: relative; /* anchors the absolute dropdown panel */
+	}
+	.fixed-mobile-bar .toc-mobile-header {
+		display: flex;
+		align-items: center;
+		height: var(--or-mobile-toc-h);
+		padding: 0 12px;
+		background: var(--page); /* opaque: content scrolls underneath while pinned */
+		border: 1px solid var(--or-border);
+		border-radius: 10px;
+		box-shadow: 0 6px 20px rgb(0 0 0 / 0.07);
+		cursor: pointer;
+	}
+	.fixed-mobile-bar .toc-mobile-header-content,
+	.fixed-mobile-bar .toc-toggle {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+		width: 100%;
+		border: 0;
+		padding: 0;
+	}
+	/* legacy [open] rule paints --theme-bg-offset at (0,2,1); out-specific it */
+	.fixed-mobile-bar .toc-mobile-container[open] .toc-toggle { background: transparent; }
+	.fixed-mobile-bar .toc-mobile-header h2 {
+		flex: none;
+		margin: 0;
+		font-family: var(--fb);
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.09em;
+		text-transform: uppercase;
+		color: var(--text-3);
+	}
+	.fixed-mobile-bar .toc-mobile-header svg {
+		flex: none;
+		fill: var(--text-3);
+		margin-inline: 2px 6px;
+	}
+	.fixed-mobile-bar .toc-current-heading {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--text);
+	}
+	.fixed-mobile-bar .or-toc-list {
+		position: absolute;
+		inset-inline: 0;
+		top: calc(var(--or-mobile-toc-h) + 6px);
+		max-height: 60svh; /* svh only — see iOS 26 note above */
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		margin: 0;
+		padding: 10px 12px;
+		background: var(--page);
+		border: 1px solid var(--or-border);
+		border-radius: 12px;
+		box-shadow: 0 18px 44px rgb(0 0 0 / 0.14);
+		transform: none; /* cancel legacy translateY */
+	}
+}
+/* Phones: the document scrolls under the fixed header — pin below it. */
+@media (max-width: 767.98px) {
+	.fixed-mobile-bar { top: calc(var(--theme-navbar-height) + 8px); }
+}
+```
+
+- [ ] **Step 2.2: Visual smoke-check (bar hidden — hydration breakpoint not yet aligned)**
+
+Browser pane at 800px width, reload `/en/deployment/deploy-aws`.
+Expected: bar VISIBLE at 800px (72em hydration already covers ≤1152px). At 1280px: NO bar (display:none >1024px), right TOC unchanged.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add public/redesign.css
+git commit -m "feat(mobile): sticky 'On this page' dropdown bar styling (≤1024px)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Align the hydration breakpoint
+
+**Files:**
+- Modify: `src/layouts/MainLayout.astro:32`
+
+`client:media="(max-width: 72em)"` hydrates up to 1152px while CSS shows the bar only ≤1024px — harmless but wasteful, and the numbers should tell one story.
+
+- [ ] **Step 3.1: Change the media query**
+
+```diff
+-							client:media="(max-width: 72em)"
++							client:media="(max-width: 1024px)"
+```
+
+- [ ] **Step 3.2: Verify hydration still happens at 800px**
+
+Reload at 800px; tap the bar → dropdown must open (proves the island hydrated with the new query).
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add src/layouts/MainLayout.astro
+git commit -m "chore(mobile-toc): align island hydration breakpoint with CSS (1024px)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Neutralize conflicting legacy rules that specificity doesn't already beat
+
+**Files:**
+- Modify: `src/components/RightSidebar/TableOfContents.css`
+
+Most legacy rules lose to the (0,2,0)+ selectors from Task 2. Two don't matter (`transform` calc with `unset` is invalid-at-computed-value → no-op) but are landmines; and the `ul` max-height (`--cur-viewport-height`, a vh-based var) violates the svh-only invariant if it ever wins. Delete them rather than override.
+
+- [ ] **Step 4.1: Delete the stale panel-geometry declarations**
+
+In `.toc-mobile-container ul` (lines 111–120), delete these three declarations only (keep the rule for its other pages/uses):
+
+```diff
+ .toc-mobile-container ul {
+-	max-height: calc( var(--cur-viewport-height) - var(--theme-navbar-height) - var(--theme-mobile-toc-height) - 1rem );
+ 	overflow-y: auto;
+ 	border: var(--theme-border);
+ 	border-radius: var(--theme-border-radius);
+ 	padding: 0.5rem 0;
+ 	font-size: var(--theme-text-sm);
+ 	background: var(--content-bg);
+-	transform: translateY(calc(-0.5rem - 0.5 * var(--header-bottom-padding)));
+ }
+```
+
+(Two deletions; the diff context above shows the survivors.)
+
+- [ ] **Step 4.2: Verify no visual change at 800px and 375px**
+
+Reload; the dropdown panel must look identical to Task 2/3 checks (redesign rules already governed these properties).
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add src/components/RightSidebar/TableOfContents.css
+git commit -m "chore(mobile-toc): drop stale vh-based panel geometry from legacy CSS
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full behavioral verification sweep (Browser pane)
+
+**Files:** none (verification only)
+
+All checks on the running dev server. Test page: `/en/deployment/deploy-aws` (many h2/h3).
+
+- [ ] **Step 5.1: Phone regime (375×812)**
+  - Bar renders under the hero, in-flow; scrolling pins it 8px below the 56px header.
+  - Current-section label updates while scrolling the DOCUMENT (the regression this plan fixes). Scroll to the very bottom: label = last section ("Have questions?").
+  - Tap bar → panel opens (≤60svh, inner-scrollable). Tap "Deploy OpenReplay" → jumps, heading NOT hidden under the pinned bar, panel closes.
+  - Tap outside the open panel → closes.
+
+- [ ] **Step 5.2: Tablet regime (800×1024)**
+  - Same checks; bar pins at the top of the inner scroller; spy follows inner scroll.
+
+- [ ] **Step 5.3: Jump-clearance contingency**
+
+If (and only if) a jumped-to heading hides under the pinned bar, add to the `@media (max-width: 1024px)` block from Task 2:
+
+```css
+	.content .heading-wrapper { scroll-margin-top: calc(80px + var(--or-mobile-toc-h)); }
+```
+
+- [ ] **Step 5.4: RTL + dark + edge cases**
+  - `/ar-ae/deployment/deploy-aws`: bar right-aligned correctly (dir=rtl), chevron/label order mirrored, panel anchored full-width.
+  - Toggle dark theme: bar/panel use dark tokens, borders visible, no white flash.
+  - A page with no h2/h3 (e.g. `/en/co-browsing` — confirm, else find one): no bar rendered, no empty sticky gap.
+  - 1280px: no bar; right TOC + its spy unchanged.
+
+- [ ] **Step 5.5: Console + logs clean**
+
+`read_console_messages(onlyErrors)` → only the known OpenReplay localhost SSL warning. `preview_logs(level:error)` → nothing new.
+
+- [ ] **Step 5.6: Final commit (if contingency or fixes were applied)**
+
+```bash
+git add -A && git commit -m "fix(mobile-toc): verification-sweep adjustments
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-07-15-mobile-toc-dropdown-design.md
+++ b/docs/superpowers/specs/2026-07-15-mobile-toc-dropdown-design.md
@@ -1,0 +1,107 @@
+# Mobile sticky "On this page" dropdown — design
+
+**Date:** 2026-07-15
+**Status:** Approved (design review with mehdi@openreplay.com)
+
+## Problem
+
+The 2026 redesign hides the right-hand "On this page" TOC at ≤1024px and force-hides
+the legacy mobile TOC bar (`redesign.css`: `.fixed-mobile-bar { display: none !important; }`).
+Result: on phones **and** tablets there is no way to jump between sections of a page.
+
+## Goal
+
+At ≤1024px, show a section-jump dropdown bar that:
+
+- renders **in-flow at the top of the article** (under the hero) and **pins below the
+  header when scrolled past** (`position: sticky`) — no JS show/hide;
+- collapsed, reads **"On this page ▸ ‹current section›"** with the current section
+  updated live by scroll-spy (doubles as a "you are here" indicator);
+- expanded, lists all h2/h3 links (same data as the desktop TOC), highlights the active
+  one, closes on link tap and on outside tap.
+
+## Approach (chosen: A — revive the existing component)
+
+The hidden `<details>`-based mobile mode of `TableOfContents.tsx` already implements the
+whole interaction (label + live section, close-on-select, close-on-outside-tap,
+translated labels, RTL, native disclosure semantics). We un-hide it, restyle it to the
+redesign language, fix its scroll-spy for the phone scroll regime, and align breakpoints.
+
+Rejected alternatives:
+- **B — new purpose-built island**: duplicates working scroll-spy/dropdown/a11y logic;
+  more code and risk for identical UX.
+- **C — native `<select>`**: cannot show the live current section when collapsed;
+  clashes with the redesign visuals.
+
+## Changes by file
+
+| File | Change |
+|---|---|
+| `public/redesign.css` | Replace the kill rule with bar + panel styling; visible ≤1024px, hidden above. |
+| `src/layouts/MainLayout.astro` | Hydration media query `(max-width: 72em)` → `(max-width: 1024px)` to match the CSS breakpoint. |
+| `src/components/RightSidebar/TableOfContents.tsx` | Scroll-spy: bind to the *actual* scroller per regime; rebind on breakpoint change. |
+| `src/components/RightSidebar/TableOfContents.css` | Retire/override conflicting legacy rules (old theme vars, `--cur-viewport-height`). |
+
+No new components. `PageContent.astro`'s `.fixed-mobile-bar` wrapper and the
+`before-article` slot stay as-is.
+
+## Behavior details
+
+### Sticky mechanics (two scroll regimes)
+
+- **Phones (<768px):** the *document* scrolls (redesign choice for iOS toolbar
+  retraction). The fixed header overlays the scroller, so the bar pins at
+  `top: var(--theme-navbar-height)`.
+- **Tablets (768–1024px):** `#or-main-scroll` is the scroller and already starts below
+  the header, so the bar pins at `top: 0`.
+
+### Scroll-spy fix (phone regime is currently broken)
+
+`TableOfContents.tsx` always binds to `#or-main-scroll`. On phones that element exists
+but is **not** the scroller, so the spy never updates and the bottom-of-page guard
+(`scrollTop`-based) never fires. Fix:
+
+- Detect the scroller with the same breakpoint redesign.css uses
+  (`max-width: 767.98px` → window/document; otherwise `#or-main-scroll`).
+- Use a viewport-anchored activation line in the window regime (the current
+  `scroller.getBoundingClientRect().top + 120` drifts as the document scrolls).
+- Re-run detection on resize / media-query change and rebind listeners.
+
+## Visual design (redesign language)
+
+- **Bar:** opaque `background: var(--page)` (content must not show through while
+  pinned), `1px solid var(--or-border)`, `border-radius: 10px`, Figtree 13–14px.
+  Label styled as the redesign eyebrow (`--text-3`, uppercase, tracked); current
+  section in `--text-1`; chevron rotates 90° when open. Soft shadow so the pinned bar
+  reads as floating.
+- **Panel:** same card treatment as the desktop TOC (surface card, `--accent` active
+  tick), `max-height: 60svh` with inner scroll.
+- **`svh` only** for the panel cap: per the iOS 26 invariants documented in
+  redesign.css (drawer comments), fixed/pinned UI must never size itself past the
+  layout viewport — no vh/lvh/dvh.
+
+## Edge cases
+
+- **No h2/h3 headings:** MainLayout already skips rendering the slot — no bar.
+- **RTL (ar-ae):** wrapper carries `dir`; use logical properties throughout; chevron
+  rotation is direction-neutral.
+- **Long titles:** single line + `text-overflow: ellipsis` (existing behavior).
+- **i18n:** `rightSidebar.onThisPage` exists in all 6 locales; layout-level change, so
+  no MDX/mirror re-porting.
+- **Anchor jumps under the pinned bar:** at ≤1024px, increase headings'
+  `scroll-margin-top` by the bar height so targets aren't obscured. The bar height is
+  declared once as a CSS custom property (e.g. `--or-mobile-toc-h`) and reused by both
+  the bar and the `scroll-margin-top` rule, so they can't drift apart.
+
+## Verification plan
+
+In the live preview (Browser pane), at 375px and 800px widths:
+
+1. Bar renders under the hero, pins below the header on scroll.
+2. Current-section label updates while scrolling **the document** (phone regime — the
+   regression case) and the inner scroller (tablet regime).
+3. Dropdown opens, link jumps to section (not obscured by the bar), closes on select
+   and on outside tap.
+4. RTL spot-check on an `/ar-ae/…` page; dark mode spot-check.
+5. A page without h2/h3 headings renders no bar.
+6. Console free of new errors; desktop (>1024px) unchanged.

--- a/docs/superpowers/specs/2026-07-15-mobile-toc-dropdown-design.md
+++ b/docs/superpowers/specs/2026-07-15-mobile-toc-dropdown-design.md
@@ -82,7 +82,11 @@ but is **not** the scroller, so the spy never updates and the bottom-of-page gua
 
 ## Edge cases
 
-- **No h2/h3 headings:** MainLayout already skips rendering the slot — no bar.
+- **No h2/h3 headings:** ~~MainLayout already skips rendering the slot — no bar.~~
+  **As built:** the original `headings && …` guard passed for an *empty array*, so
+  MainLayout now checks `headings.some(h => h.depth > 1 && h.depth < 4)`; and because
+  Astro emits the slot wrapper even when the expression is falsy, redesign.css also
+  hides `.fixed-mobile-bar:not(:has(details.toc-mobile-container))`.
 - **RTL (ar-ae):** wrapper carries `dir`; use logical properties throughout; chevron
   rotation is direction-neutral.
 - **Long titles:** single line + `text-overflow: ellipsis` (existing behavior).
@@ -92,6 +96,12 @@ but is **not** the scroller, so the spy never updates and the bottom-of-page gua
   `scroll-margin-top` by the bar height so targets aren't obscured. The bar height is
   declared once as a CSS custom property (e.g. `--or-mobile-toc-h`) and reused by both
   the bar and the `scroll-margin-top` rule, so they can't drift apart.
+  **As built:** the anchor ids sit on the headings themselves (whose scroll-margin is
+  0), not on `.heading-wrapper`, so *scroller padding* is the reliable lever instead:
+  `#or-main-scroll { scroll-padding-top: calc(var(--or-mobile-toc-h) + 24px) }` for the
+  tablet regime, and on phones the `html` scroll-padding is retuned to
+  `calc(navbar + var(--or-mobile-toc-h) + 16px)` — snug under the bar and above the
+  scroll-spy activation line, so the label is correct right after a jump.
 
 ## Verification plan
 

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -171,8 +171,100 @@ body.mobile-sidebar-toggle header {
 	height: auto;
 }
 
-/* hide the legacy mobile TOC bar — design hides TOC on small screens */
-.fixed-mobile-bar { display: none !important; }
+/* ===================== MOBILE "ON THIS PAGE" BAR ===================== */
+/* Shown wherever the right-hand TOC is hidden (≤1024px, next block). In-flow at the
+   top of the article, pins on scroll (position:sticky). Phones pin below the fixed
+   header (the DOCUMENT scrolls there); tablets pin at the top of the inner
+   #or-main-scroll scroller (which already starts below the header).
+   Bar height lives in --or-mobile-toc-h so any future offset rules share one source.
+   The dropdown panel's max-height uses svh ONLY — never vh/lvh/dvh — per the iOS 26
+   layout-viewport clipping notes on .or-drawer above.
+   Selectors are ≥(0,2,0) on purpose: the component's legacy TableOfContents.css is
+   bundled into <style> tags whose order vs this file is not guaranteed, so we win on
+   specificity, not order. */
+:root { --or-mobile-toc-h: 44px; }
+
+.fixed-mobile-bar { display: none; }
+
+@media (max-width: 1024px) {
+	.fixed-mobile-bar {
+		display: block;
+		position: sticky;
+		top: 8px; /* tablet: #or-main-scroll's top edge is already below the header */
+		z-index: 10;
+		margin-bottom: 18px;
+	}
+	.fixed-mobile-bar .toc-mobile-container {
+		display: block;
+		position: relative; /* anchors the absolute dropdown panel */
+	}
+	.fixed-mobile-bar .toc-mobile-header {
+		display: flex;
+		align-items: center;
+		height: var(--or-mobile-toc-h);
+		padding: 0 12px;
+		background: var(--page); /* opaque: content scrolls underneath while pinned */
+		border: 1px solid var(--or-border);
+		border-radius: 10px;
+		box-shadow: 0 6px 20px rgb(0 0 0 / 0.07);
+		cursor: pointer;
+	}
+	.fixed-mobile-bar .toc-mobile-header-content,
+	.fixed-mobile-bar .toc-toggle {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+		width: 100%;
+		border: 0;
+		padding: 0;
+	}
+	/* legacy [open] rule paints --theme-bg-offset at (0,2,1); out-specific it */
+	.fixed-mobile-bar .toc-mobile-container[open] .toc-toggle { background: transparent; }
+	.fixed-mobile-bar .toc-mobile-header h2 {
+		flex: none;
+		margin: 0;
+		font-family: var(--fb);
+		font-size: 11px;
+		font-weight: 600;
+		letter-spacing: 0.09em;
+		text-transform: uppercase;
+		color: var(--text-3);
+	}
+	.fixed-mobile-bar .toc-mobile-header svg {
+		flex: none;
+		fill: var(--text-3);
+		margin-inline: 2px 6px;
+	}
+	.fixed-mobile-bar .toc-current-heading {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--text);
+	}
+	.fixed-mobile-bar .or-toc-list {
+		position: absolute;
+		inset-inline: 0;
+		top: calc(var(--or-mobile-toc-h) + 6px);
+		max-height: 60svh; /* svh only — see iOS 26 note above */
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		margin: 0;
+		padding: 10px 12px;
+		background: var(--page);
+		border: 1px solid var(--or-border);
+		border-radius: 12px;
+		box-shadow: 0 18px 44px rgb(0 0 0 / 0.14);
+		transform: none; /* cancel legacy translateY */
+	}
+}
+/* Phones: the document scrolls under the fixed header — pin below it. */
+@media (max-width: 767.98px) {
+	.fixed-mobile-bar { top: calc(var(--theme-navbar-height) + 8px); }
+}
 
 @media (max-width: 1024px) {
 	.or-toc { display: none !important; }

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -532,6 +532,10 @@ body.mobile-sidebar-toggle header {
 	top: 15px;
 	width: 18px;
 	height: 18px;
+	/* reset the 0.1rem 1rem padding inherited from index.css's `blockquote:before`;
+	   otherwise the box is 50px wide and `mask: center / contain` re-centres the icon
+	   ~14px to the right, bleeding it into the "Note:" label. */
+	padding: 0;
 	background: var(--note-ic);
 	-webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M12%202C6.48%202%202%206.48%202%2012s4.48%2010%2010%2010%2010-4.48%2010-10S17.52%202%2012%202zm1%2015h-2v-6h2v6zm0-8h-2V7h2v2z'/%3E%3C/svg%3E") center / contain no-repeat;
 	mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20d='M12%202C6.48%202%202%206.48%202%2012s4.48%2010%2010%2010%2010-4.48%2010-10S17.52%202%2012%202zm1%2015h-2v-6h2v6zm0-8h-2V7h2v2z'/%3E%3C/svg%3E") center / contain no-repeat;

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -181,22 +181,30 @@ body.mobile-sidebar-toggle header {
    layout-viewport clipping notes on .or-drawer above.
    Selectors are ≥(0,2,0) on purpose: the component's legacy TableOfContents.css is
    bundled into <style> tags whose order vs this file is not guaranteed, so we win on
-   specificity, not order. */
+   specificity, not order.
+   The `display` toggles carry !important: PageContent.astro's *scoped* <style> sets
+   `.fixed-mobile-bar { display: block }` unconditionally (hiding it only at ≥80em),
+   which the Astro-scoped selector makes as specific as this plain one. Without
+   !important our base hide loses in the 1025–1279px gap (≤1024px here, ≥1280px there),
+   rendering BOTH this bar and the desktop .or-toc. !important restores the win — same
+   pattern as the sibling `.or-toc { display: none !important }` rule below. */
 :root { --or-mobile-toc-h: 44px; }
 
-.fixed-mobile-bar { display: none; }
+.fixed-mobile-bar { display: none !important; }
 
 @media (max-width: 1024px) {
 	.fixed-mobile-bar {
-		display: block;
+		display: block !important;
 		position: sticky;
 		top: 8px; /* tablet: #or-main-scroll's top edge is already below the header */
 		z-index: 10;
 		margin-bottom: 18px;
 	}
 	/* Pages without h2/h3 headings: MainLayout skips the TOC island, but Astro still
-	   emits the empty slot wrapper — hide it so it doesn't leave a sticky 18px gap. */
-	.fixed-mobile-bar:not(:has(details.toc-mobile-container)) { display: none; }
+	   emits the empty slot wrapper — hide it so it doesn't leave a sticky 18px gap.
+	   !important so it still wins over the block !important above (it does on
+	   specificity too, but keep both important to avoid a silent regression). */
+	.fixed-mobile-bar:not(:has(details.toc-mobile-container)) { display: none !important; }
 	.fixed-mobile-bar .toc-mobile-container {
 		display: block;
 		position: relative; /* anchors the absolute dropdown panel */

--- a/public/redesign.css
+++ b/public/redesign.css
@@ -194,6 +194,9 @@ body.mobile-sidebar-toggle header {
 		z-index: 10;
 		margin-bottom: 18px;
 	}
+	/* Pages without h2/h3 headings: MainLayout skips the TOC island, but Astro still
+	   emits the empty slot wrapper — hide it so it doesn't leave a sticky 18px gap. */
+	.fixed-mobile-bar:not(:has(details.toc-mobile-container)) { display: none; }
 	.fixed-mobile-bar .toc-mobile-container {
 		display: block;
 		position: relative; /* anchors the absolute dropdown panel */
@@ -245,6 +248,12 @@ body.mobile-sidebar-toggle header {
 		font-weight: 600;
 		color: var(--text);
 	}
+	/* Anchor jumps must land clear of the pinned bar. Phones already reserve space
+	   via index.css's html scroll-padding (the DOCUMENT is the scroller there); this
+	   covers the tablet regime, where #or-main-scroll is the scroller. The anchor ids
+	   sit on the headings themselves (not .heading-wrapper), so scroller padding is
+	   the reliable lever. */
+	#or-main-scroll { scroll-padding-top: calc(var(--or-mobile-toc-h) + 24px); }
 	.fixed-mobile-bar .or-toc-list {
 		position: absolute;
 		inset-inline: 0;
@@ -264,6 +273,11 @@ body.mobile-sidebar-toggle header {
 /* Phones: the document scrolls under the fixed header — pin below it. */
 @media (max-width: 767.98px) {
 	.fixed-mobile-bar { top: calc(var(--theme-navbar-height) + 8px); }
+	/* Anchor-jump landing offset for the document scroller. index.css reserves the
+	   LEGACY bar's 4rem (--theme-mobile-toc-height); size it to the real bar instead
+	   so targets land snug under it — and above the scroll-spy activation line
+	   (~120px), so the current-section label is correct right after a jump. */
+	html { scroll-padding-top: calc(var(--theme-navbar-height) + var(--or-mobile-toc-h) + 16px); }
 }
 
 @media (max-width: 1024px) {

--- a/src/components/RightSidebar/TableOfContents.css
+++ b/src/components/RightSidebar/TableOfContents.css
@@ -109,14 +109,12 @@
 }
 
 .toc-mobile-container ul {
-	max-height: calc( var(--cur-viewport-height) - var(--theme-navbar-height) - var(--theme-mobile-toc-height) - 1rem );
 	overflow-y: auto;
 	border: var(--theme-border);
 	border-radius: var(--theme-border-radius);
 	padding: 0.5rem 0;
 	font-size: var(--theme-text-sm);
 	background: var(--content-bg);
-	transform: translateY(calc(-0.5rem - 0.5 * var(--header-bottom-padding)));
 }
 
 .toc-mobile-container .header-link {

--- a/src/components/RightSidebar/TableOfContents.css
+++ b/src/components/RightSidebar/TableOfContents.css
@@ -119,8 +119,8 @@
 
 .toc-mobile-container .header-link {
 	border: 0;
-	padding-left: 1rem;
-	padding-right: .5rem;
+	padding-inline-start: 1rem;
+	padding-inline-end: .5rem;
 }
 
 .toc-mobile-container .header-link a {

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -45,13 +45,15 @@ const TableOfContents: FunctionalComponent<Props> = ({ headings = [], labels, is
     };
 
     useEffect(() => {
-        // Position-based scroll-spy against the actual scroll container
-        // (#or-main-scroll). An IntersectionObserver top-zone can never
-        // activate the LAST heading (nothing below it pushes it into the zone),
-        // so we pick the last heading above an activation line and add an
-        // explicit "scrolled to bottom" guard.
-        const scroller =
-            (typeof document !== 'undefined' && document.getElementById('or-main-scroll')) || null;
+        // Position-based scroll-spy. Two scroll regimes (see redesign.css "APP SHELL"):
+        // phones (<768px) scroll the DOCUMENT; wider screens scroll #or-main-scroll.
+        // Bind both — only the real scroller emits scroll events — and resolve the
+        // active regime on every update so resizing across the breakpoint just works.
+        // An IntersectionObserver top-zone can never activate the LAST heading
+        // (nothing below it pushes it into the zone), so we pick the last heading
+        // above an activation line and add an explicit "scrolled to bottom" guard.
+        const phoneMQ = window.matchMedia('(max-width: 767.98px)');
+        const innerScroller = document.getElementById('or-main-scroll');
         const headingEls = () =>
             headings
                 .map(({ slug }) => document.getElementById(slug))
@@ -60,6 +62,9 @@ const TableOfContents: FunctionalComponent<Props> = ({ headings = [], labels, is
         const update = () => {
             const els = headingEls();
             if (!els.length) return;
+            const scroller = phoneMQ.matches ? null : innerScroller;
+            // Document regime: the line is viewport-anchored (top = 0). Inner regime:
+            // anchored to the scroller's top edge, as before.
             const top = scroller ? scroller.getBoundingClientRect().top : 0;
             const line = top + 120; // activation line ~120px below the scroll area's top
             let cur = els[0].id;
@@ -67,22 +72,21 @@ const TableOfContents: FunctionalComponent<Props> = ({ headings = [], labels, is
                 if (el.getBoundingClientRect().top <= line) cur = el.id;
             }
             // At (or near) the bottom, the last section is the active one.
-            if (
-                scroller &&
-                scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 8
-            ) {
+            const sc = scroller ?? (document.scrollingElement as HTMLElement | null);
+            if (sc && sc.scrollHeight - sc.scrollTop - sc.clientHeight < 8) {
                 cur = els[els.length - 1].id;
             }
             setCurrentID(cur);
         };
 
-        const target: HTMLElement | Window = scroller || window;
-        target.addEventListener('scroll', update, { passive: true });
+        window.addEventListener('scroll', update, { passive: true });
+        innerScroller?.addEventListener('scroll', update, { passive: true });
         window.addEventListener('resize', update);
         update();
 
         return () => {
-            target.removeEventListener('scroll', update);
+            window.removeEventListener('scroll', update);
+            innerScroller?.removeEventListener('scroll', update);
             window.removeEventListener('resize', update);
         };
     }, [headings.map((h) => h.slug).join('|')]);

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -25,7 +25,9 @@ import Modal from '../components/Modal.astro';
 	<RightSidebar slot="secondary-sidebar" headings={headings} content={content} githubEditUrl={githubEditUrl} />
 	<PageContent {...{content, previous, next}}>
 		{
-			headings && (
+			/* Match the component's own depth filter (h2/h3): an empty headings array is
+			   truthy and would render a pointless empty dropdown bar on mobile. */
+			headings && headings.some((h: { depth: number }) => h.depth > 1 && h.depth < 4) && (
 				<Fragment slot="before-article">
 					<nav>
 						<TableOfContents

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -29,7 +29,7 @@ import Modal from '../components/Modal.astro';
 				<Fragment slot="before-article">
 					<nav>
 						<TableOfContents
-							client:media="(max-width: 72em)"
+							client:media="(max-width: 1024px)"
 							headings={headings}
 							labels={{
 								onThisPage: t('rightSidebar.onThisPage') || 'On This Page',


### PR DESCRIPTION
## Summary

Since the 2026 redesign hid the right-hand TOC at ≤1024px **and** force-hid the legacy mobile TOC bar, phones and tablets had no way to jump between sections of a page. This PR revives the hidden `<details>`-based mobile TOC as a redesign-styled sticky dropdown bar:

- **Sticky "On this page ▸ ‹current section›" bar at ≤1024px** — in-flow at the top of the article, pins below the header on scroll. Phones pin below the fixed header (document scroller); tablets pin at the top of the inner `#or-main-scroll` scroller. The current-section label updates live while scrolling.
- **Scroll-spy fix (`TableOfContents.tsx`)** — the spy only bound `#or-main-scroll`, but on phones the redesign scrolls the *document* (iOS toolbar retraction), so tracking never updated there. It now binds both candidate scrollers and resolves the regime per update; the bottom-of-page guard uses `document.scrollingElement` in the document regime. Desktop behavior unchanged.
- **Anchor-jump clearance** — `#or-main-scroll` gets its own `scroll-padding-top` (the anchor ids sit on the headings, whose `scroll-margin` is 0), and the phone `html` scroll-padding is retuned from the legacy 4rem bar to the real bar height, so targets land snug under the pinned bar and the label is correct right after a jump.
- **Edge cases** — pages without h2/h3 headings no longer render an empty bar (empty `headings` array is truthy; MainLayout now mirrors the component's depth filter, plus a `:has()` guard for Astro's statically-emitted slot wrapper). Panel max-height uses `svh` only, per the iOS 26 layout-viewport invariants documented on `.or-drawer`; stale vh-based geometry removed from the legacy component CSS.
- **Unrelated one-liner** — the note-callout ⓘ icon bled into the "Note:" label: the `::before` inherited `padding: 0.1rem 1rem` from index.css, inflating its box to 50px and re-centering the `mask: center/contain` icon into the text. Reset to `padding: 0`.

Design spec and implementation plan are included under `docs/superpowers/`.

This is a layout/CSS-level change — it applies to all 6 locales (incl. RTL) and all doc versions with no MDX changes.

## Test plan

Verified against the local dev server at 375×812 (phone), 800×1024 (tablet), 1280×900 (desktop):

- [x] Bar renders under the hero and pins below the header on scroll (both scroll regimes)
- [x] Current-section label follows document scroll on phones (the regression case) and inner scroll on tablets; bottom of page activates the last section
- [x] Dropdown opens, link jump lands clear of the pinned bar, panel closes on select and on outside tap
- [x] RTL (`/ar-ae/…`): bar and panel fully mirrored; label translated
- [x] Dark mode tokens
- [x] Page with no h2/h3 headings renders no bar
- [x] Desktop (>1024px) unchanged: no bar, right TOC + spy intact
- [x] Console/dev-server logs clean (only pre-existing tracker warning / worktree font-allowlist noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)