### PR TITLE
Fix iOS 26 drawer cut short again: unstick the TOC bar while the drawer is open

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -205,6 +205,19 @@ body.mobile-sidebar-toggle header {
 	   !important so it still wins over the block !important above (it does on
 	   specificity too, but keep both important to avoid a silent regression). */
 	.fixed-mobile-bar:not(:has(details.toc-mobile-container)) { display: none !important; }
+	/* While the hamburger drawer is open, drop the bar out of the sticky
+	   (viewport-constrained) layer set. iOS 26.0 WebKit mis-sizes viewport-sized
+	   FIXED containers when its toolbar/layout-viewport recompute fires
+	   (webkit.org/blog/17541 "bottom gap ... viewport-sized fixed containers",
+	   bugs.webkit.org 158055568; trigger cluster: 297779, 300523) — the drawer
+	   rendered cut short again once this always-present sticky bar started
+	   engaging/disengaging on every page scroll. The bar sits behind the
+	   full-screen #mobile-overlay whenever the drawer is open, so demoting it to
+	   static there is invisible to users and removes the extra
+	   viewport-constrained layer at the exact commit where the drawer must be
+	   sized. body-prefixed selector = (0,2,1), deterministically beating
+	   PageContent.astro's scoped sticky rule at (0,2,0). */
+	body.mobile-sidebar-toggle .fixed-mobile-bar { position: static; }
 	.fixed-mobile-bar .toc-mobile-container {
 		display: block;
 		position: relative; /* anchors the absolute dropdown panel */


### PR DESCRIPTION
## Summary

#290 reintroduced the iOS 26 symptom #289 fixed: on iPhone Safari (iOS 26.0), the hamburger drawer renders cut short at the bottom.

**Root cause (investigated, not guessed):** the drawer CSS is untouched and correct — the drawer/overlay block is byte-identical to #289's fix, inset-anchored, no viewport units (exhaustive diff audit + live production check confirmed this). The regression comes from a WebKit iOS 26.0 bug: *"bottom gap appearing on layouts with viewport-sized fixed containers"* ([fixed in Safari 26.1](https://webkit.org/blog/17541/), bug 158055568; trigger cluster [297779](https://bugs.webkit.org/show_bug.cgi?id=297779), [300523](https://bugs.webkit.org/show_bug.cgi?id=300523) — toolbar/layout-viewport recomputes firing on scroll discontinuities). #290's sticky "On this page" bar is a **new viewport-constrained layer engaging/disengaging on every page scroll**, which fires that buggy recompute path constantly — resurfacing the drawer bottom-gap that inset anchoring had avoided in practice. (`scroll-padding`, the `60svh` panel, and the scroll listeners were investigated and affirmatively cleared.)

**Fix (one declaration):** while the drawer is open (`body.mobile-sidebar-toggle`), demote the bar to `position: static`. The bar sits behind the full-screen overlay in that state, so this is invisible to users — and it removes the extra viewport-constrained layer at the exact commit where the drawer must be sized.

## Test plan

- [x] Chromium 375×812: bar stuck (sticky, y=64) → drawer opens **full height** (56→812) with bar computed `static` → close restores `sticky` at the same position, no scroll jump
- [x] Rule scoped inside the ≤1024px block; desktop unaffected
- [ ] **On-device (please verify, @estradino):** iPhone iOS 26.0 Safari — open the hamburger menu at page top AND after scrolling; the drawer should reach the screen bottom in both cases. To test before merging: `npm run dev -- --host` on your Mac, then open `http://<mac-lan-ip>:4399` on the iPhone.
- [ ] If it still reproduces on-device, note whether the device is on 26.0 or 26.1+ — on 26.1+ the WebKit core bug is fixed and we'd be looking at the 26.2 sticky-clipping cluster instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)