### PR TITLE
i18n(v1.27): sync ios-sdk/init.mdx + plugins/assist.mdx to EN

### DIFF
--- a/src/pages/ar-ae/ios-sdk/init.mdx
+++ b/src/pages/ar-ae/ios-sdk/init.mdx
@@ -93,6 +93,7 @@ func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options conn
 - `logs: Bool` يُفعّل مستمع السجلّات (logs).
 - `screen: Bool` يُفعّل مُسجّل الشاشة.
 - `wifiOnly: Bool` يُجبر المتتبّع على البدء فقط إذا كان لدى المستخدم اتصال wifi.
+- `isBlur: Bool` يُموّه العروض (views) الحساسة (عند `true`) أو يغطّيها بمربّع صلب (عند `false`). القيمة الافتراضية هي `true`.
 
 ## الوحدات
 <div class="grid grid-cols-12 md:grid-cols-12 gap-3 md:gap-4">

--- a/src/pages/ar-ae/plugins/assist.mdx
+++ b/src/pages/ar-ae/plugins/assist.mdx
@@ -106,15 +106,83 @@ trackerAssist({
    * Minimum amount of MESSAGES in a batch to trigger compression run
    * @default 5000
    * */
-   compressionMinBatchSize: number
+  compressionMinBatchSize: number;
+  /**
+   * Show only the first part of an agent's name in the call popup
+   * (e.g. "One Two" -> "One").
+   * @default false
+   */
+  agentShortNames: boolean;
+  /**
+   * Postpone assist start until a userID is set on the session.
+   * @default false
+   */
+  ignoreAnonymous: boolean;
+  /**
+   * When assist connects to the server:
+   * - Autostart.Auto (default): always on tracker start.
+   * - Autostart.Disabled: only via an explicit start() call.
+   * - Autostart.Continuation: only via assist.start(), but the choice is remembered
+   *   in sessionStorage so it auto-continues across page reloads until assist.stop().
+   * @default Autostart.Auto
+   */
+  autostart: Autostart;
+  /**
+   * Require explicit user confirmation before anything is shared with an
+   * agent: assist starts and opens the socket as usual, but no messages are
+   * sent through it until the user approves the confirmation popup, which is
+   * shown as soon as the first agent connects to the session. The approval
+   * is remembered per-tab (sessionStorage) until stop() is called.
+   * @default false
+   */
+  requestConfirm: boolean;
+  /** Text/style customization for the session view confirmation popup. */
+  sessionConfirm?: ConfirmOptions;
+  /** Called when the user approves session viewing (requestConfirm mode). */
+  onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;
+  /** Called when the user denies session viewing (requestConfirm mode). */
+  onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;
 })
 ```
 
 ### تخصيص عناصر الواجهة (Widgets)
 
-يمكن تخصيص كل من التحكم عن بُعد وعناصر واجهة المكالمة، تلك التي يراها المستخدم النهائي، تخصيصاً كاملاً.
+يمكن تخصيص العرض المباشر والتحكم عن بُعد وكذلك عناصر واجهة المكالمة، تلك التي يراها المستخدم النهائي، تخصيصاً كاملاً.
+
+#### عنصر واجهة العرض المباشر
+
+اضبط `requestConfirm: true` لطلب إذن المستخدم قبل أن يتمكّن الوكيل من مشاهدة جلسته مباشرةً. يبدأ Assist ويتصل كالمعتاد، لكن تبقى الجلسة غير مرئية للوكيل حتى يوافق المستخدم على النافذة المنبثقة للتأكيد، التي تظهر بمجرد اتصال أول وكيل. بمجرد القبول، يُعاد تشغيل التتبّع ويصبح بإمكان الوكيل حينها رؤية جلسة المستخدم مباشرةً.
+
+يتم تذكّر الموافقة لكل تبويب (في `sessionStorage`) حتى يتم استدعاء [`stop()`](#methods)، الذي يُلغيها، بحيث سيطلب [`start()`](#methods) التالي التأكيد مجدداً.
+
+```js
+tracker.use(trackerAssist({
+  requestConfirm: true,
+  sessionConfirm: { text: 'A support agent would like to view your screen. Allow?' },
+  onSessionConfirmApprove: ({ email, name, query }) => console.log("Session viewing approved"),
+  onSessionConfirmDeny: ({ email, name, query }) => console.log("Session viewing denied"),
+}));
+```
+
+يمكن تخصيص نص النافذة المنبثقة ونمطها عبر خيار `sessionConfirm`، الذي يأخذ كائن `ConfirmOptions` التالي:
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 #### عنصر واجهة التحكم عن بُعد
+
+يمكن تخصيص نص النافذة المنبثقة ونمطها عبر خيار `controlConfirm`، الذي يأخذ كائن `ConfirmOptions` التالي:
 
 ```js
 type ConfirmOptions = {
@@ -131,6 +199,22 @@ type ButtonOptions = HTMLButtonElement | string | {
 ```
 
 #### عنصر واجهة المكالمة
+
+يمكن تخصيص نص النافذة المنبثقة ونمطها عبر خيار `callConfirm`، الذي يأخذ كائن `ConfirmOptions` التالي:
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 من الممكن تخصيص كل جانب من جوانب عنصر الواجهة هذا عبر مجموعة `ids` و`classes` التالية. تُستخدم `Ids` كنقاط ربط للأزرار/العناصر الفردية، بينما يمكن استخدام `classes` لحاويات المجموعات.
 
@@ -213,6 +297,22 @@ onRecordingDeny: ({ email, name, query }) => {
 }
 ```
 
+- `onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;`: تُستدعى دالة الاستدعاء هذه عندما يوافق المستخدم على مشاهدة الجلسة (في وضع [`requestConfirm`](#session-view-confirmation)) وتعيد تفاصيل الوكيل (email والاسم وquery).
+
+```js
+onSessionConfirmApprove: ({ email, name, query }) => {
+  console.log("Session viewing approved for", email)
+}
+```
+
+- `onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;`: تُستدعى دالة الاستدعاء هذه عندما يرفض المستخدم مشاهدة الجلسة (في وضع [`requestConfirm`](#session-view-confirmation)) وتعيد تفاصيل الوكيل (email والاسم وquery).
+
+```js
+onSessionConfirmDeny: ({ email, name, query }) => {
+  console.log("Session viewing denied")
+}
+```
+
 - `onDragCamera?: (dx: number, dy: number) => any;`: تتوقّع هذه الدالة معالِجاً يحدّد سلوك زر الفأرة المضغوط داخل لوحة Three.js canvas للتحكم عن بُعد. يستقبل المعالِج dx وdy، اللذين يشيران إلى مقادير حركة الفأرة.
 
 ```js
@@ -220,6 +320,24 @@ onDragCamera: (dx, dy) => {
   moveCamera(dx, dy)
 }
 ```
+
+## الطرق
+
+تُعيد `tracker.use()` نسخة assist، التي تكشف طرقاً للتحكّم في assist أثناء التشغيل:
+
+```js
+const assist = tracker.use(trackerAssist(options));
+
+assist.stop();
+assist.start();
+```
+
+- `start()`: يعيد تشغيل assist (أو يشغّله). لا يفعل شيئاً إذا لم يكن المتتبّع نفسه نشطاً بعد (سيبدأ assist مع المتتبّع). في وضع `Autostart.Continuation`، يحفظ علامة في `sessionStorage` بحيث يستمر assist تلقائياً عبر عمليات إعادة تحميل الصفحة. كما أن استدعاء `start()` الصريح يتجاوز أي تأجيل بسبب `ignoreAnonymous`.
+- `stop()`: يوقف assist عن طريق قطع اتصال المقبس (socket) وتنظيف جميع الاتصالات. لن يُعاد تشغيل assist تلقائياً حتى يتم استدعاء `start()`. في وضع `Autostart.Continuation`، يمسح هذا أيضاً العلامة المحفوظة، بحيث لن تستمر إعادة التحميل تلقائياً. في وضع [`requestConfirm`](#session-view-confirmation)، يُلغي أيضاً موافقة المستخدم، بحيث سيطلب `start()` التالي التأكيد مجدداً.
+
+<Aside type="caution">
+  تُعيد `tracker.use()` القيمة `undefined` في البيئات التي لا يمكن فيها تحميل assist (مثل عدم دعم أجهزة الوسائط، أو داخل iframe)، لذا احرص على التحقّق من النسخة المُعادة وفقاً لذلك.
+</Aside>
 
 ## هل لديك أسئلة؟
 

--- a/src/pages/es/ios-sdk/init.mdx
+++ b/src/pages/es/ios-sdk/init.mdx
@@ -93,6 +93,7 @@ Consulta [cómo sanear los datos en las reproducciones de iOS](/ios-sdk/sanitiza
 - `logs: Bool` Habilita el listener de logs.
 - `screen: Bool` Habilita el grabador de pantalla.
 - `wifiOnly: Bool` Obliga al tracker a iniciarse solo si el usuario tiene una conexión wifi.
+- `isBlur: Bool` Difumina las vistas sensibles (cuando es `true`) o las cubre con un recuadro sólido (cuando es `false`). El valor por defecto es `true`.
 
 ## Módulos
 <div class="grid grid-cols-12 md:grid-cols-12 gap-3 md:gap-4">

--- a/src/pages/es/plugins/assist.mdx
+++ b/src/pages/es/plugins/assist.mdx
@@ -106,15 +106,83 @@ trackerAssist({
    * Minimum amount of MESSAGES in a batch to trigger compression run
    * @default 5000
    * */
-   compressionMinBatchSize: number
+  compressionMinBatchSize: number;
+  /**
+   * Show only the first part of an agent's name in the call popup
+   * (e.g. "One Two" -> "One").
+   * @default false
+   */
+  agentShortNames: boolean;
+  /**
+   * Postpone assist start until a userID is set on the session.
+   * @default false
+   */
+  ignoreAnonymous: boolean;
+  /**
+   * When assist connects to the server:
+   * - Autostart.Auto (default): always on tracker start.
+   * - Autostart.Disabled: only via an explicit start() call.
+   * - Autostart.Continuation: only via assist.start(), but the choice is remembered
+   *   in sessionStorage so it auto-continues across page reloads until assist.stop().
+   * @default Autostart.Auto
+   */
+  autostart: Autostart;
+  /**
+   * Require explicit user confirmation before anything is shared with an
+   * agent: assist starts and opens the socket as usual, but no messages are
+   * sent through it until the user approves the confirmation popup, which is
+   * shown as soon as the first agent connects to the session. The approval
+   * is remembered per-tab (sessionStorage) until stop() is called.
+   * @default false
+   */
+  requestConfirm: boolean;
+  /** Text/style customization for the session view confirmation popup. */
+  sessionConfirm?: ConfirmOptions;
+  /** Called when the user approves session viewing (requestConfirm mode). */
+  onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;
+  /** Called when the user denies session viewing (requestConfirm mode). */
+  onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;
 })
 ```
 
 ### Personalización de los widgets
 
-Tanto el control remoto como los widgets de llamada, los que ve el usuario final, se pueden personalizar por completo.
+La vista en vivo, el control remoto, así como los widgets de llamada, los que ve el usuario final, se pueden personalizar por completo.
+
+#### Widget de vista en vivo
+
+Establece `requestConfirm: true` para requerir el permiso del usuario antes de que un agente pueda ver su sesión en vivo. Assist se inicia y se conecta como de costumbre, pero la sesión permanece invisible para el agente hasta que el usuario apruebe el popup de confirmación, que se muestra en cuanto el primer agente se conecta. Una vez aceptado, el seguimiento se reinicia y el agente puede entonces ver la sesión del usuario en vivo.
+
+La aprobación se recuerda por pestaña (en `sessionStorage`) hasta que se llama a [`stop()`](#methods), que la revoca, por lo que el siguiente [`start()`](#methods) volverá a solicitarla.
+
+```js
+tracker.use(trackerAssist({
+  requestConfirm: true,
+  sessionConfirm: { text: 'A support agent would like to view your screen. Allow?' },
+  onSessionConfirmApprove: ({ email, name, query }) => console.log("Session viewing approved"),
+  onSessionConfirmDeny: ({ email, name, query }) => console.log("Session viewing denied"),
+}));
+```
+
+El texto y el estilo del popup se pueden personalizar mediante la opción `sessionConfirm`, que toma el siguiente objeto `ConfirmOptions`:
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 #### Widget de control remoto
+
+El texto y el estilo del popup se pueden personalizar mediante la opción `controlConfirm`, que toma el siguiente objeto `ConfirmOptions`:
 
 ```js
 type ConfirmOptions = {
@@ -131,6 +199,22 @@ type ButtonOptions = HTMLButtonElement | string | {
 ```
 
 #### Widget de llamada
+
+El texto y el estilo del popup se pueden personalizar mediante la opción `callConfirm`, que toma el siguiente objeto `ConfirmOptions`:
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 Es posible personalizar todos los aspectos de este widget mediante el siguiente conjunto de `ids` y `classes`. Los `Ids` sirven como anclas para botones/elementos individuales, mientras que las `classes` pueden usarse para contenedores de grupo.
 
@@ -213,6 +297,22 @@ onRecordingDeny: ({ email, name, query }) => {
 }
 ```
 
+- `onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;`: Esta función de callback se dispara cuando el usuario aprueba la visualización de la sesión (en modo [`requestConfirm`](#session-view-confirmation)) y devuelve los detalles del agente (email, nombre y query).
+
+```js
+onSessionConfirmApprove: ({ email, name, query }) => {
+  console.log("Session viewing approved for", email)
+}
+```
+
+- `onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;`: Esta función de callback se dispara cuando el usuario deniega la visualización de la sesión (en modo [`requestConfirm`](#session-view-confirmation)) y devuelve los detalles del agente (email, nombre y query).
+
+```js
+onSessionConfirmDeny: ({ email, name, query }) => {
+  console.log("Session viewing denied")
+}
+```
+
 - `onDragCamera?: (dx: number, dy: number) => any;`: Esta función espera un handler que defina el comportamiento de un botón del ratón mantenido pulsado dentro de un canvas de Three.js para control remoto. El handler recibe dx y dy, que indican los deltas de movimiento del ratón.
 
 ```js
@@ -220,6 +320,24 @@ onDragCamera: (dx, dy) => {
   moveCamera(dx, dy)
 }
 ```
+
+## Métodos
+
+`tracker.use()` devuelve la instancia de assist, que expone métodos para controlar assist en tiempo de ejecución:
+
+```js
+const assist = tracker.use(trackerAssist(options));
+
+assist.stop();
+assist.start();
+```
+
+- `start()`: (Re)inicia assist. No hace nada si el propio tracker aún no está activo (assist se iniciará junto con el tracker). En el modo `Autostart.Continuation`, persiste un flag en `sessionStorage` para que assist continúe automáticamente entre recargas de página. Un `start()` explícito también anula cualquier aplazamiento de `ignoreAnonymous`.
+- `stop()`: Detiene assist desconectando el socket y limpiando todas las conexiones. Assist no se reiniciará automáticamente hasta que se llame a `start()`. En el modo `Autostart.Continuation`, esto también borra el flag persistido, por lo que una recarga no continuará automáticamente. En el modo [`requestConfirm`](#session-view-confirmation), también revoca la aprobación del usuario, por lo que el siguiente `start()` volverá a solicitarla.
+
+<Aside type="caution">
+  `tracker.use()` devuelve `undefined` en entornos donde assist no puede cargarse (por ejemplo, sin soporte de dispositivos multimedia, dentro de un iframe), así que protege la instancia devuelta en consecuencia.
+</Aside>
 
 ## ¿Tienes preguntas?
 

--- a/src/pages/fr/ios-sdk/init.mdx
+++ b/src/pages/fr/ios-sdk/init.mdx
@@ -93,6 +93,7 @@ Consultez [comment assainir les données dans les rejeux iOS](/ios-sdk/sanitizat
 - `logs: Bool` Active l'écouteur de logs.
 - `screen: Bool` Active l'enregistreur d'écran.
 - `wifiOnly: Bool` Force le tracker à ne démarrer que si l'utilisateur dispose d'une connexion wifi.
+- `isBlur: Bool` Floute les vues sensibles (lorsque `true`) ou les recouvre d'un bloc opaque (lorsque `false`). La valeur par défaut est `true`.
 
 ## Modules
 <div class="grid grid-cols-12 md:grid-cols-12 gap-3 md:gap-4">

--- a/src/pages/fr/plugins/assist.mdx
+++ b/src/pages/fr/plugins/assist.mdx
@@ -106,15 +106,83 @@ trackerAssist({
    * Minimum amount of MESSAGES in a batch to trigger compression run
    * @default 5000
    * */
-   compressionMinBatchSize: number
+  compressionMinBatchSize: number;
+  /**
+   * Show only the first part of an agent's name in the call popup
+   * (e.g. "One Two" -> "One").
+   * @default false
+   */
+  agentShortNames: boolean;
+  /**
+   * Postpone assist start until a userID is set on the session.
+   * @default false
+   */
+  ignoreAnonymous: boolean;
+  /**
+   * When assist connects to the server:
+   * - Autostart.Auto (default): always on tracker start.
+   * - Autostart.Disabled: only via an explicit start() call.
+   * - Autostart.Continuation: only via assist.start(), but the choice is remembered
+   *   in sessionStorage so it auto-continues across page reloads until assist.stop().
+   * @default Autostart.Auto
+   */
+  autostart: Autostart;
+  /**
+   * Require explicit user confirmation before anything is shared with an
+   * agent: assist starts and opens the socket as usual, but no messages are
+   * sent through it until the user approves the confirmation popup, which is
+   * shown as soon as the first agent connects to the session. The approval
+   * is remembered per-tab (sessionStorage) until stop() is called.
+   * @default false
+   */
+  requestConfirm: boolean;
+  /** Text/style customization for the session view confirmation popup. */
+  sessionConfirm?: ConfirmOptions;
+  /** Called when the user approves session viewing (requestConfirm mode). */
+  onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;
+  /** Called when the user denies session viewing (requestConfirm mode). */
+  onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;
 })
 ```
 
 ### Personnalisation des widgets
 
-Le contrôle à distance ainsi que les widgets d'appel, ceux que voit l'utilisateur final, peuvent être entièrement personnalisés.
+La vue en direct, le contrôle à distance ainsi que les widgets d'appel, ceux que voit l'utilisateur final, peuvent être entièrement personnalisés.
+
+#### Widget de vue en direct
+
+Définissez `requestConfirm: true` pour exiger la permission de l'utilisateur avant qu'un agent puisse voir sa session en direct. Assist démarre et se connecte comme d'habitude, mais la session reste invisible pour l'agent jusqu'à ce que l'utilisateur approuve la popup de confirmation, qui s'affiche dès que le premier agent se connecte. Une fois acceptée, le suivi redémarre et l'agent peut alors voir la session de l'utilisateur en direct.
+
+L'approbation est mémorisée par onglet (dans `sessionStorage`) jusqu'à ce que [`stop()`](#methods) soit appelé, ce qui la révoque, de sorte que le prochain [`start()`](#methods) redemandera.
+
+```js
+tracker.use(trackerAssist({
+  requestConfirm: true,
+  sessionConfirm: { text: 'A support agent would like to view your screen. Allow?' },
+  onSessionConfirmApprove: ({ email, name, query }) => console.log("Session viewing approved"),
+  onSessionConfirmDeny: ({ email, name, query }) => console.log("Session viewing denied"),
+}));
+```
+
+Le texte et le style de la popup peuvent être personnalisés via l'option `sessionConfirm`, qui prend l'objet `ConfirmOptions` ci-dessous :
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 #### Widget de contrôle à distance
+
+Le texte et le style de la popup peuvent être personnalisés via l'option `controlConfirm`, qui prend l'objet `ConfirmOptions` ci-dessous :
 
 ```js
 type ConfirmOptions = {
@@ -131,6 +199,22 @@ type ButtonOptions = HTMLButtonElement | string | {
 ```
 
 #### Widget d'appel
+
+Le texte et le style de la popup peuvent être personnalisés via l'option `callConfirm`, qui prend l'objet `ConfirmOptions` ci-dessous :
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 Il est possible de personnaliser tous les aspects de ce widget grâce à l'ensemble de `ids` et `classes` ci-dessous. Les `Ids` servent d'ancres pour les boutons/éléments individuels, tandis que les `classes` peuvent être utilisées pour les conteneurs de groupe.
 
@@ -213,6 +297,22 @@ onRecordingDeny: ({ email, name, query }) => {
 }
 ```
 
+- `onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;` : Cette fonction de callback est déclenchée lorsque l'utilisateur approuve la visualisation de la session (en mode [`requestConfirm`](#session-view-confirmation)) et renvoie les détails de l'agent (email, nom et query).
+
+```js
+onSessionConfirmApprove: ({ email, name, query }) => {
+  console.log("Session viewing approved for", email)
+}
+```
+
+- `onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;` : Cette fonction de callback est déclenchée lorsque l'utilisateur refuse la visualisation de la session (en mode [`requestConfirm`](#session-view-confirmation)) et renvoie les détails de l'agent (email, nom et query).
+
+```js
+onSessionConfirmDeny: ({ email, name, query }) => {
+  console.log("Session viewing denied")
+}
+```
+
 - `onDragCamera?: (dx: number, dy: number) => any;` : Cette fonction attend un handler qui définit le comportement d'un bouton de souris maintenu enfoncé à l'intérieur d'un canvas Three.js pour le contrôle à distance. Le handler reçoit dx et dy, indiquant les deltas de mouvement de la souris.
 
 ```js
@@ -220,6 +320,24 @@ onDragCamera: (dx, dy) => {
   moveCamera(dx, dy)
 }
 ```
+
+## Méthodes
+
+`tracker.use()` renvoie l'instance assist, qui expose des méthodes pour contrôler assist au moment de l'exécution :
+
+```js
+const assist = tracker.use(trackerAssist(options));
+
+assist.stop();
+assist.start();
+```
+
+- `start()` : (Re)démarre assist. C'est une opération sans effet si le tracker lui-même n'est pas encore actif (assist démarrera en même temps que le tracker). En mode `Autostart.Continuation`, il persiste un indicateur dans `sessionStorage` afin qu'assist se poursuive automatiquement lors des rechargements de page. Un appel explicite à `start()` remplace également tout report dû à `ignoreAnonymous`.
+- `stop()` : Arrête assist en déconnectant le socket et en nettoyant toutes les connexions. Assist ne redémarrera pas automatiquement tant que `start()` n'est pas appelé. En mode `Autostart.Continuation`, cela efface également l'indicateur persistant, de sorte qu'un rechargement ne se poursuivra pas automatiquement. En mode [`requestConfirm`](#session-view-confirmation), cela révoque également l'approbation de l'utilisateur, de sorte que le prochain `start()` redemandera.
+
+<Aside type="caution">
+  `tracker.use()` renvoie `undefined` dans les environnements où assist ne peut pas se charger (par exemple, absence de prise en charge des périphériques multimédias, à l'intérieur d'une iframe), veillez donc à protéger l'instance renvoyée en conséquence.
+</Aside>
 
 ## Des questions ?
 

--- a/src/pages/ru/ios-sdk/init.mdx
+++ b/src/pages/ru/ios-sdk/init.mdx
@@ -93,6 +93,7 @@ func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options conn
 - `logs: Bool` Включает слушатель логов.
 - `screen: Bool` Включает запись экрана.
 - `wifiOnly: Bool` Заставляет трекер запускаться только при наличии у пользователя wifi-соединения.
+- `isBlur: Bool` Размывает конфиденциальные представления (когда `true`) или закрывает их сплошным блоком (когда `false`). По умолчанию `true`.
 
 ## Модули
 <div class="grid grid-cols-12 md:grid-cols-12 gap-3 md:gap-4">

--- a/src/pages/ru/plugins/assist.mdx
+++ b/src/pages/ru/plugins/assist.mdx
@@ -106,15 +106,83 @@ trackerAssist({
    * Minimum amount of MESSAGES in a batch to trigger compression run
    * @default 5000
    * */
-   compressionMinBatchSize: number
+  compressionMinBatchSize: number;
+  /**
+   * Show only the first part of an agent's name in the call popup
+   * (e.g. "One Two" -> "One").
+   * @default false
+   */
+  agentShortNames: boolean;
+  /**
+   * Postpone assist start until a userID is set on the session.
+   * @default false
+   */
+  ignoreAnonymous: boolean;
+  /**
+   * When assist connects to the server:
+   * - Autostart.Auto (default): always on tracker start.
+   * - Autostart.Disabled: only via an explicit start() call.
+   * - Autostart.Continuation: only via assist.start(), but the choice is remembered
+   *   in sessionStorage so it auto-continues across page reloads until assist.stop().
+   * @default Autostart.Auto
+   */
+  autostart: Autostart;
+  /**
+   * Require explicit user confirmation before anything is shared with an
+   * agent: assist starts and opens the socket as usual, but no messages are
+   * sent through it until the user approves the confirmation popup, which is
+   * shown as soon as the first agent connects to the session. The approval
+   * is remembered per-tab (sessionStorage) until stop() is called.
+   * @default false
+   */
+  requestConfirm: boolean;
+  /** Text/style customization for the session view confirmation popup. */
+  sessionConfirm?: ConfirmOptions;
+  /** Called when the user approves session viewing (requestConfirm mode). */
+  onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;
+  /** Called when the user denies session viewing (requestConfirm mode). */
+  onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;
 })
 ```
 
 ### Настройка виджетов
 
-Как удалённое управление, так и виджеты звонков, которые видит конечный пользователь, можно полностью настроить.
+Просмотр в реальном времени, удалённое управление, а также виджеты звонков, которые видит конечный пользователь, можно полностью настроить.
+
+#### Виджет просмотра в реальном времени
+
+Установите `requestConfirm: true`, чтобы требовать разрешения пользователя, прежде чем агент сможет просматривать его сессию в реальном времени. Assist запускается и подключается как обычно, но сессия остаётся невидимой для агента до тех пор, пока пользователь не подтвердит запрос во всплывающем окне, которое показывается, как только к сессии подключается первый агент. После принятия отслеживание перезапускается, и агент может видеть сессию пользователя в реальном времени.
+
+Разрешение запоминается для каждой вкладки (в `sessionStorage`) до вызова [`stop()`](#methods), который его отзывает, поэтому следующий вызов [`start()`](#methods) снова покажет запрос.
+
+```js
+tracker.use(trackerAssist({
+  requestConfirm: true,
+  sessionConfirm: { text: 'A support agent would like to view your screen. Allow?' },
+  onSessionConfirmApprove: ({ email, name, query }) => console.log("Session viewing approved"),
+  onSessionConfirmDeny: ({ email, name, query }) => console.log("Session viewing denied"),
+}));
+```
+
+Текст и стиль всплывающего окна можно настроить с помощью опции `sessionConfirm`, которая принимает приведённый ниже объект `ConfirmOptions`:
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 #### Виджет удалённого управления
+
+Текст и стиль всплывающего окна можно настроить с помощью опции `controlConfirm`, которая принимает приведённый ниже объект `ConfirmOptions`:
 
 ```js
 type ConfirmOptions = {
@@ -131,6 +199,22 @@ type ButtonOptions = HTMLButtonElement | string | {
 ```
 
 #### Виджет звонка
+
+Текст и стиль всплывающего окна можно настроить с помощью опции `callConfirm`, которая принимает приведённый ниже объект `ConfirmOptions`:
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 Можно настроить каждый аспект этого виджета с помощью приведённого ниже набора `ids` и `classes`. `Ids` служат якорями для отдельных кнопок/элементов, тогда как `classes` могут использоваться для групповых контейнеров.
 
@@ -213,6 +297,22 @@ onRecordingDeny: ({ email, name, query }) => {
 }
 ```
 
+- `onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;`: Эта функция обратного вызова срабатывает, когда пользователь подтверждает просмотр сессии (в режиме [`requestConfirm`](#session-view-confirmation)), и возвращает данные агента (email, имя и query).
+
+```js
+onSessionConfirmApprove: ({ email, name, query }) => {
+  console.log("Session viewing approved for", email)
+}
+```
+
+- `onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;`: Эта функция обратного вызова срабатывает, когда пользователь отклоняет просмотр сессии (в режиме [`requestConfirm`](#session-view-confirmation)), и возвращает данные агента (email, имя и query).
+
+```js
+onSessionConfirmDeny: ({ email, name, query }) => {
+  console.log("Session viewing denied")
+}
+```
+
 - `onDragCamera?: (dx: number, dy: number) => any;`: Эта функция ожидает обработчик, который определяет поведение удерживаемой кнопки мыши внутри canvas Three.js для удалённого управления. Обработчик получает dx и dy, указывающие на дельты движения мыши.
 
 ```js
@@ -220,6 +320,24 @@ onDragCamera: (dx, dy) => {
   moveCamera(dx, dy)
 }
 ```
+
+## Методы
+
+`tracker.use()` возвращает экземпляр assist, который предоставляет методы для управления assist во время выполнения:
+
+```js
+const assist = tracker.use(trackerAssist(options));
+
+assist.stop();
+assist.start();
+```
+
+- `start()`: (Пере)запускает assist. Это безоперационный вызов, если сам трекер ещё не активен (assist запустится вместе с трекером). В режиме `Autostart.Continuation` он сохраняет флаг в `sessionStorage`, чтобы assist автоматически продолжал работу при перезагрузках страницы. Явный вызов `start()` также отменяет любую отсрочку `ignoreAnonymous`.
+- `stop()`: Останавливает assist, отключая сокет и очищая все соединения. Assist не перезапустится автоматически до вызова `start()`. В режиме `Autostart.Continuation` это также очищает сохранённый флаг, поэтому перезагрузка не приведёт к автопродолжению. В режиме [`requestConfirm`](#session-view-confirmation) это также отзывает разрешение пользователя, поэтому следующий вызов `start()` снова покажет запрос.
+
+<Aside type="caution">
+  `tracker.use()` возвращает `undefined` в средах, где assist не может загрузиться (например, отсутствует поддержка медиаустройств, внутри iframe), поэтому проверяйте возвращаемый экземпляр соответствующим образом.
+</Aside>
 
 ## Есть вопросы?
 

--- a/src/pages/zh/ios-sdk/init.mdx
+++ b/src/pages/zh/ios-sdk/init.mdx
@@ -93,6 +93,7 @@ func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options conn
 - `logs: Bool` 启用日志监听器。
 - `screen: Bool` 启用屏幕录制器。
 - `wifiOnly: Bool` 强制追踪器仅在用户拥有 wifi 连接时启动。
+- `isBlur: Bool` 对敏感视图进行模糊处理（当为 `true` 时），或用纯色方块覆盖它们（当为 `false` 时）。默认为 `true`。
 
 ## 模块
 <div class="grid grid-cols-12 md:grid-cols-12 gap-3 md:gap-4">

--- a/src/pages/zh/plugins/assist.mdx
+++ b/src/pages/zh/plugins/assist.mdx
@@ -106,15 +106,83 @@ trackerAssist({
    * Minimum amount of MESSAGES in a batch to trigger compression run
    * @default 5000
    * */
-   compressionMinBatchSize: number
+  compressionMinBatchSize: number;
+  /**
+   * Show only the first part of an agent's name in the call popup
+   * (e.g. "One Two" -> "One").
+   * @default false
+   */
+  agentShortNames: boolean;
+  /**
+   * Postpone assist start until a userID is set on the session.
+   * @default false
+   */
+  ignoreAnonymous: boolean;
+  /**
+   * When assist connects to the server:
+   * - Autostart.Auto (default): always on tracker start.
+   * - Autostart.Disabled: only via an explicit start() call.
+   * - Autostart.Continuation: only via assist.start(), but the choice is remembered
+   *   in sessionStorage so it auto-continues across page reloads until assist.stop().
+   * @default Autostart.Auto
+   */
+  autostart: Autostart;
+  /**
+   * Require explicit user confirmation before anything is shared with an
+   * agent: assist starts and opens the socket as usual, but no messages are
+   * sent through it until the user approves the confirmation popup, which is
+   * shown as soon as the first agent connects to the session. The approval
+   * is remembered per-tab (sessionStorage) until stop() is called.
+   * @default false
+   */
+  requestConfirm: boolean;
+  /** Text/style customization for the session view confirmation popup. */
+  sessionConfirm?: ConfirmOptions;
+  /** Called when the user approves session viewing (requestConfirm mode). */
+  onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;
+  /** Called when the user denies session viewing (requestConfirm mode). */
+  onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;
 })
 ```
 
 ### 微件自定义
 
-远程控制以及通话微件，即终端用户所看到的那些，都可以完全自定义。
+实时查看、远程控制以及通话微件，即终端用户所看到的那些，都可以完全自定义。
+
+#### 实时查看微件
+
+将 `requestConfirm: true` 设置为在坐席能够实时查看用户会话之前先获得用户的许可。Assist 会照常启动并连接，但在用户批准确认弹窗之前，会话对坐席保持不可见，该弹窗会在第一个坐席连接时立即显示。一旦被接受，追踪将重新启动，坐席便可以实时查看用户的会话。
+
+该批准会按标签页记住（存储在 `sessionStorage` 中），直到调用 [`stop()`](#methods)，此调用会撤销该批准，因此下一次 [`start()`](#methods) 将会再次提示。
+
+```js
+tracker.use(trackerAssist({
+  requestConfirm: true,
+  sessionConfirm: { text: 'A support agent would like to view your screen. Allow?' },
+  onSessionConfirmApprove: ({ email, name, query }) => console.log("Session viewing approved"),
+  onSessionConfirmDeny: ({ email, name, query }) => console.log("Session viewing denied"),
+}));
+```
+
+可以通过 `sessionConfirm` 选项来自定义弹窗的文本和样式，该选项接受以下 `ConfirmOptions` 对象：
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 #### 远程控制微件
+
+可以通过 `controlConfirm` 选项来自定义弹窗的文本和样式，该选项接受以下 `ConfirmOptions` 对象：
 
 ```js
 type ConfirmOptions = {
@@ -131,6 +199,22 @@ type ButtonOptions = HTMLButtonElement | string | {
 ```
 
 #### 通话微件
+
+可以通过 `callConfirm` 选项来自定义弹窗的文本和样式，该选项接受以下 `ConfirmOptions` 对象：
+
+```js
+type ConfirmOptions = {
+  text?:string,
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+  confirmBtn?: ButtonOptions, 
+  declineBtn?: ButtonOptions
+}
+
+type ButtonOptions = HTMLButtonElement | string | {
+  innerHTML?: string, // to pass an svg string or text
+  style?: StyleObject, // style object (i.e {color: 'red', borderRadius: '10px'})
+}
+```
 
 可以通过以下这组 `ids` 和 `classes` 来自定义此微件的各个方面。`Ids` 用作各个按钮/元素的锚点，而 `classes` 可用于分组容器。
 
@@ -213,6 +297,22 @@ onRecordingDeny: ({ email, name, query }) => {
 }
 ```
 
+- `onSessionConfirmApprove?: (agentInfo: Record<string, any>) => any;`：此回调函数在用户批准会话查看（处于 [`requestConfirm`](#session-view-confirmation) 模式）时触发，并返回坐席的详细信息（email、名称和 query）。
+
+```js
+onSessionConfirmApprove: ({ email, name, query }) => {
+  console.log("Session viewing approved for", email)
+}
+```
+
+- `onSessionConfirmDeny?: (agentInfo: Record<string, any>) => any;`：此回调函数在用户拒绝会话查看（处于 [`requestConfirm`](#session-view-confirmation) 模式）时触发，并返回坐席的详细信息（email、名称和 query）。
+
+```js
+onSessionConfirmDeny: ({ email, name, query }) => {
+  console.log("Session viewing denied")
+}
+```
+
 - `onDragCamera?: (dx: number, dy: number) => any;`：此函数需要一个处理程序，用于定义在用于远程控制的 Three.js canvas 内按住鼠标按钮的行为。该处理程序接收 dx 和 dy，表示鼠标移动的增量。
 
 ```js
@@ -220,6 +320,24 @@ onDragCamera: (dx, dy) => {
   moveCamera(dx, dy)
 }
 ```
+
+## 方法
+
+`tracker.use()` 返回 assist 实例，该实例暴露了可在运行时控制 assist 的方法：
+
+```js
+const assist = tracker.use(trackerAssist(options));
+
+assist.stop();
+assist.start();
+```
+
+- `start()`：（重新）启动 assist。如果追踪器本身尚未激活，则此操作为空操作（assist 将与追踪器一起启动）。在 `Autostart.Continuation` 模式下，它会在 `sessionStorage` 中持久化一个标志，以便 assist 在页面重新加载后自动继续。显式的 `start()` 还会取代任何 `ignoreAnonymous` 延迟。
+- `stop()`：通过断开套接字连接并清理所有连接来停止 assist。在调用 `start()` 之前，assist 不会自动重新启动。在 `Autostart.Continuation` 模式下，这还会清除已持久化的标志，因此重新加载不会自动继续。在 [`requestConfirm`](#session-view-confirmation) 模式下，它还会撤销用户的批准，因此下一次 `start()` 将会再次提示。
+
+<Aside type="caution">
+  在 assist 无法加载的环境中（例如不支持媒体设备、位于 iframe 内），`tracker.use()` 会返回 `undefined`，因此请相应地对返回的实例进行防护。
+</Aside>
 
 ## 有疑问？
 


### PR DESCRIPTION
## What

Ports two recent EN documentation updates into the **v1.27** localized pages (the unversioned `es/`, `fr/`, `ru/`, `zh/`, `ar-ae/` folders — v1.27.0 maps to `url: ''` in `src/config.ts`). Archived version folders (v1.26.0 and earlier) are intentionally untouched.

Source commits:
- [`0c0f798`](https://github.com/openreplay/documentation/commit/0c0f7987e542199801536287195aa108608293f9) — `ios-sdk/init.mdx`: add the `isBlur: Bool` initialization option.
- [`8e24690`](https://github.com/openreplay/documentation/commit/8e24690bee06dcd04e1ad4ebbb94a94dd6f21758) — `plugins/assist.mdx`: "Live view confirmation" restructure.

## Scope note

The locale `assist.mdx` files had drifted several revisions behind EN (all ~226 lines vs EN's 344) — they were missing the `Methods` section, the `requestConfirm`/`sessionConfirm`/`autostart` options, and several callbacks that the new content references. Applying only the literal two-commit delta would have produced broken pages (dangling `#methods` anchors, references to undefined options). Each `assist.mdx` was therefore brought to **full structural parity** with current EN:

- Existing translations are **reused verbatim** — no churn on already-translated sections.
- Only new/changed sections were freshly translated: Widgets Customization intro, **Live View Widget**, `controlConfirm`/`callConfirm` intros + type blocks, `onSessionConfirmApprove`/`onSessionConfirmDeny` callbacks, and the **Methods** section.

## Conventions followed

- All fenced **code blocks copied byte-for-byte from EN** (incl. English JSDoc comments) — verified identical across all 5 locales.
- Same-page **anchor slugs kept in English** (`#methods`, `#session-view-confirmation`), matching how sibling translations in this repo already link.
- **Heading structure matches EN 1:1** (14 headings, identical levels/order) in every locale.
- Frontmatter left unchanged.

## Verification

- ✅ 19/19 code blocks byte-identical to EN in all 5 locales (programmatic diff)
- ✅ Heading count/levels/order match EN 1:1
- ✅ Anchor slugs identical to EN
- ✅ No MDX-hostile characters; `<Aside>` components intact (1 tip + 1 caution each)
- ✅ `init.mdx`: exactly one translated `isBlur` bullet added after `wifiOnly`

> ⚠️ Pre-existing EN issue (not fixed here, to keep locales mirroring EN): the `#session-view-confirmation` anchor in EN no longer resolves after that heading was renamed to "Live View Widget". Translations replicate EN faithfully; worth fixing on the EN source separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)