### PR TITLE
mobile: opt into viewport-fit=cover so the iOS drawer reaches the screen bottom

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -87,7 +87,14 @@ body {
 /* mobile drawer */
 .or-drawer {
 	background: var(--page);
-	padding: 14px 12px 0;
+	/* Bottom/inline padding pays the safe-area tax now that the document is full-bleed
+	   (viewport-fit=cover in HeadCommon.astro): the drawer reaches the physical screen
+	   bottom, so the last nav row would otherwise sit under the home indicator and the
+	   floating iOS 26 toolbar. env() resolves to 0 where there is no inset (desktop,
+	   Android, portrait Safari tabs), so these collapse to the original values. */
+	padding-top: 14px;
+	padding-inline: max(12px, env(safe-area-inset-left, 0px)) max(12px, env(safe-area-inset-right, 0px));
+	padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 12px);
 	border-inline-end: 1px solid var(--or-border);
 	transform: translateX(-100%);
 	/* `display:none` when closed removes the drawer from the layout entirely. A
@@ -100,18 +107,16 @@ body {
 	   it (which made it hard to scroll the menu back up on iOS). */
 	overscroll-behavior: contain;
 	/* Height comes from inset anchoring — the markup's `top-14 bottom-0` — and NOT from
-	   an explicit viewport-unit height. iOS 26 Safari (Liquid Glass) CLIPS fixed content
-	   that extends past the layout-viewport bottom instead of painting it behind the
-	   toolbar, so the previous `height: calc(100lvh - navbar)` lost its bottom slice
-	   whenever the toolbar was expanded: menu visibly cut short, dark band below it
-	   (Safari's own chrome-tint fill). Fixed upstream in Safari 26.1
-	   (webkit.org/blog/17541, "bottom gap ... viewport-sized fixed containers"), but
-	   26.0 devices remain. An lvh height was also broken on OLDER iOS: the bottom
-	   toolbar-slice of the drawer's own scrollport sat offscreen and a scroll container
-	   can't reveal its own offscreen portion, so the last nav items were unreachable.
-	   A top+bottom-anchored fixed element tracks the layout viewport in BOTH toolbar
-	   states on every iOS version (same pattern as Starlight/Docusaurus/shadcn).
+	   an explicit viewport-unit height. A vh/lvh/dvh height is wrong twice over: it
+	   overshoots the layout viewport (and WebKit CLIPS position:fixed to the inner
+	   viewport, so the overshoot is discarded, never painted behind the toolbar), and it
+	   puts the bottom slice of the drawer's OWN scrollport offscreen — a scroll container
+	   cannot reveal its own offscreen portion, so the last nav items become unreachable.
 	   Do NOT add height/min-height in vh/lvh/dvh units here.
+	   Inset anchoring only reaches the LAYOUT-viewport bottom, which on iOS 26 sits well
+	   above the physical screen bottom. Extending it is not a CSS job at all — it needs
+	   `viewport-fit=cover` on the meta viewport (see HeadCommon.astro). Without that opt-in
+	   the leftover strip is painted by Safari itself and reads as "the menu is cut short".
 	   The open/close transition lives on the open-state rule below (not here) so closing
 	   is INSTANT — otherwise the drawer lingers ~0.25s before display:none, keeping iOS's
 	   viewport pinned and flashing the gap back (the "weird half-second delay"). */
@@ -124,8 +129,11 @@ body {
 	height: 38px;
 }
 [dir='rtl'] .or-drawer { transform: translateX(100%); }
-/* Second box-shadow = paint-only bleed below the drawer (same reason as #mobile-overlay). */
-body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3), 0 120px 0 0 var(--page); transition: transform 0.25s ease, display 0.25s allow-discrete; }
+/* No "bleed" shadow here: a second `0 120px 0 0` shadow used to try to paint the drawer's
+   background into the strip below the layout viewport, but WebKit clips position:fixed
+   painting to the inner viewport (even with negative offsets), so it was a no-op on exactly
+   the iOS versions it was added for. viewport-fit=cover is what actually closes that strip. */
+body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); transition: transform 0.25s ease, display 0.25s allow-discrete; }
 /* Slide-in start state (for the display:none → block transition above). */
 @starting-style {
 	body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(-100%); }
@@ -138,13 +146,20 @@ body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; tran
 /* display:none when closed (same reason as the drawer above) — keep the overlay out of
    the layout so it can't pin iOS Safari's viewport once the menu has been used.
    Sized by the markup's `inset-0` (inset anchoring, not viewport units) for the same
-   iOS 26 clipping reason as the drawer above. The box-shadow is a PAINT-ONLY bleed:
-   on pre-26 iOS the layout viewport ends at the expanded toolbar's top edge, and the
-   translucent toolbar would otherwise show the un-dimmed page through its glass — the
-   solid downward shadow paints the overlay's black into that strip without affecting
-   layout. Never turn this into a height/min-height (see the drawer note above). */
-#mobile-overlay { display: none; touch-action: none; box-shadow: 0 120px 0 0 rgb(0 0 0 / 0.9); }
+   reason as the drawer above; never turn that into a height/min-height. Its bleed
+   box-shadow was removed too — see the note on the drawer's open-state rule. */
+#mobile-overlay { display: none; touch-action: none; }
 body.mobile-sidebar-toggle #mobile-overlay { display: block; }
+
+/* The open-state rules above (specificity 0,3,1 / 1,1,1) out-rank the markup's Tailwind
+   `md:hidden` (0,1,0), so with the drawer open a rotation to landscape on a large phone
+   (≥768px) left the drawer AND the full-screen overlay on screen — while the hamburger
+   that would close them is itself md:hidden. Nothing drops the body class on resize, so
+   the page was stuck behind a black overlay. This guard cannot be out-specified. */
+@media (min-width: 768px) {
+	#mobile-left-sidebar.or-drawer,
+	#mobile-overlay { display: none !important; }
+}
 
 /* We deliberately do NOT lock the page scroll with `overflow:hidden` on html/body when
    the drawer opens. On phones the document is the scroller, and toggling overflow on the
@@ -205,19 +220,18 @@ body.mobile-sidebar-toggle header {
 	   !important so it still wins over the block !important above (it does on
 	   specificity too, but keep both important to avoid a silent regression). */
 	.fixed-mobile-bar:not(:has(details.toc-mobile-container)) { display: none !important; }
-	/* While the hamburger drawer is open, drop the bar out of the sticky
-	   (viewport-constrained) layer set. iOS 26.0 WebKit mis-sizes viewport-sized
-	   FIXED containers when its toolbar/layout-viewport recompute fires
-	   (webkit.org/blog/17541 "bottom gap ... viewport-sized fixed containers",
-	   bugs.webkit.org 158055568; trigger cluster: 297779, 300523) — the drawer
-	   rendered cut short again once this always-present sticky bar started
-	   engaging/disengaging on every page scroll. The bar sits behind the
-	   full-screen #mobile-overlay whenever the drawer is open, so demoting it to
-	   static there is invisible to users and removes the extra
-	   viewport-constrained layer at the exact commit where the drawer must be
-	   sized. body-prefixed selector = (0,2,1), deterministically beating
-	   PageContent.astro's scoped sticky rule at (0,2,0). */
-	body.mobile-sidebar-toggle .fixed-mobile-bar { position: static; }
+	/* NOTE — do not re-add a `body.mobile-sidebar-toggle .fixed-mobile-bar { position: static }`
+	   rule here. PR #291 added one, believing this bar re-triggered an iOS 26.0 bug that
+	   cut the drawer short. That was wrong on two counts:
+	     1. The cited bug (Apple Radar 158055568) was already FIXED. webkit.org/blog/17541 is
+	        the "WebKit Features for Safari 26.1" release post (2025-11-03) and the quoted
+	        line is a RESOLVED-issues entry, not an open report. Independently confirmed by
+	        mui/material-ui#46953, closed after re-testing on the 26.1 simulator.
+	     2. Even if it were live, the rule only applies once the drawer is ALREADY open,
+	        while the trigger it blamed (sticky engage/disengage) happens during earlier
+	        scrolling — and the demotion lands in the same style/layout pass that sizes the
+	        drawer, so there is no second measurement for it to influence.
+	   The real cause was the missing `viewport-fit=cover` opt-in (see HeadCommon.astro). */
 	.fixed-mobile-bar .toc-mobile-container {
 		display: block;
 		position: relative; /* anchors the absolute dropdown panel */
@@ -307,8 +321,15 @@ body.mobile-sidebar-toggle header {
 	.or-footer-wrap { padding-left: 40px; padding-right: 40px; }
 }
 @media (max-width: 768px) {
-	.or-main-wrap { padding: 24px 22px 70px; }
-	.or-footer-wrap { padding: 0 22px 40px; }
+	/* max(22px, env(...)) keeps the reading column clear of the sensor housing / rounded
+	   corners in landscape now that viewport-fit=cover makes the document full-bleed.
+	   env() is 0 wherever there is no inset, so these stay 22px on every other device. */
+	.or-main-wrap {
+		padding: 24px max(22px, env(safe-area-inset-right, 0px)) 70px max(22px, env(safe-area-inset-left, 0px));
+	}
+	.or-footer-wrap {
+		padding: 0 max(22px, env(safe-area-inset-right, 0px)) 40px max(22px, env(safe-area-inset-left, 0px));
+	}
 	.or-left { width: 284px; }
 }
 

--- a/src/components/HeadCommon.astro
+++ b/src/components/HeadCommon.astro
@@ -6,7 +6,15 @@ import { cssVersions } from '../util/cssVersions';
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width" />
+<!-- viewport-fit=cover is REQUIRED for full-bleed fixed overlays on iOS 26 (Liquid Glass).
+     Without it the layout viewport stops at the safe-area boundary, well above the physical
+     screen bottom, and because the iOS 26 toolbar now FLOATS rather than occupying a solid
+     strip, Safari paints that leftover gap itself with a flat sampled colour — which is the
+     "band below the menu" the mobile drawer kept showing. `bottom: 0` can only ever reach
+     the layout-viewport bottom, so this opt-in is the only author-side lever that extends it.
+     Every element that touches a screen edge must pay the safe-area tax with
+     env(safe-area-inset-*) — see the `max(..., env(...))` paddings in redesign.css. -->
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 <meta name="theme-color" content="hsl(256, 44%, 15%)" media="(prefers-color-scheme: dark)" />
 <meta name="theme-color" content="hsl(273, 37%, 93%)" media="(prefers-color-scheme: light)" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -118,7 +118,10 @@ const docsearchStrings = getDocSearchStrings(Astro);
 		top: 0;
 		right: 0;
 		z-index: 9999;
-		padding: 0 22px;
+		/* Safe-area tax: viewport-fit=cover (HeadCommon.astro) makes the document
+		   full-bleed, so in landscape the logo/actions would sit under the sensor
+		   housing without this. env() is 0 where there is no inset. */
+		padding: 0 max(22px, env(safe-area-inset-right, 0px)) 0 max(22px, env(safe-area-inset-left, 0px));
 		background-color: var(--header-bg);
 		-webkit-backdrop-filter: blur(10px);
 		backdrop-filter: blur(10px);
@@ -221,7 +224,11 @@ const docsearchStrings = getDocSearchStrings(Astro);
 	/* show/hide helpers (≤768px = mobile) */
 	.hide-sm { display: inline-flex; }
 	@media (max-width: 768px) {
-		header { padding: 0 14px; }
+		/* keeps the safe-area tax from the base rule — this override is the one that
+		   actually applies on phones, which is where landscape insets matter */
+		header {
+			padding: 0 max(14px, env(safe-area-inset-right, 0px)) 0 max(14px, env(safe-area-inset-left, 0px));
+		}
 		.nav-wrapper { gap: 8px; }
 		.hide-sm { display: none !important; }
 	}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -102,7 +102,10 @@ const { title, description, breadcrumb = [] } = Astro.props as Props;
 
 	@media (max-width: 768px) {
 		.or-hero { padding: 26px 0 24px; }
-		.or-hero-inner { padding-inline: 22px; }
+		/* Safe-area tax for landscape under viewport-fit=cover (see HeadCommon.astro). */
+		.or-hero-inner {
+			padding-inline: max(22px, env(safe-area-inset-left, 0px)) max(22px, env(safe-area-inset-right, 0px));
+		}
 		.or-hero-h1 { font-size: 30px; }
 		.or-hero-desc { font-size: 15px; }
 		.or-hero-dots { width: 120px; }


### PR DESCRIPTION
## Why the menu is still cut short

Two separate findings. The first is uncomfortable but important:

### 1. PR #291 fixed a bug that had already been fixed eight months earlier

#291 blamed Apple Radar **158055568** and cited `webkit.org/blog/17541`. That URL is not a bug report — it is the **"WebKit Features for Safari 26.1"** release post, and the line it quotes sits in the **Resolved Issues** section:

> "Fixed a bottom gap appearing on layouts with viewport-sized fixed containers on iOS. (158055568)"

So the bug was fixed on **2025-11-03**, eight months before #291 was written. Independently confirmed: [mui/material-ui#46953](https://github.com/mui/material-ui/issues/46953) — the same bug filed against MUI's Drawer with the same `fixed` + `inset:0` construction — was closed 2025-11-11 after re-testing on the 26.1 simulator. Every WebKit release post from 26.2 → 26.6 and the Safari 27 beta post were checked; nothing reintroduces it. Current iOS is **26.6** (shipped 2026-07-27); 26.0 is 15 releases stale.

#291's rule was also structurally unable to help even if the bug had been live: it applies only once the drawer is **already open**, while the trigger it blamed (sticky engage/disengage) happens during earlier scrolling — and the demotion lands in the *same* style/layout pass that sizes the drawer, so there is no second measurement for it to influence. It has been removed, with the reasoning recorded in-place so the next person doesn't re-enter this dead end.

### 2. The actual defect: the site never opted into `viewport-fit=cover`

Without it, iOS insets the layout viewport. Since #289 the drawer is anchored `top-14 bottom-0`, so `bottom: 0` resolves to **that inset boundary — above the physical screen bottom**. Pre-iOS-26 the leftover strip was hidden behind an opaque toolbar. The iOS 26 toolbar *floats*, so Safari paints that strip itself with a flat sampled colour. Verbatim from a Safari 26.5-era field write-up:

> "Without `viewport-fit=cover`, the page content stops at the safe area boundary. Safari renders a solid bar in the gap between your content and the toolbar."
> "If you don't set it, the fallback is white (light) or black (dark) — which looks like a solid bar."

That is exactly the reported screenshot. And #289's `box-shadow` "bleeds" could never have covered it — **WebKit clips `position:fixed` painting to the inner viewport even with negative offsets** (Devon Govett, in the MUI thread). Both bleeds are removed; they were no-ops encoding a false "gap is handled" claim.

## What changed

- **`viewport-fit=cover`** (+ `initial-scale=1`) on the meta viewport — the only author-side lever that extends the layout viewport.
- **Safe-area tax**, which that opt-in makes mandatory: `env(safe-area-inset-*)` on the drawer, header, hero, and content/footer wraps, so a full-bleed document doesn't push content under the sensor housing in landscape. `env()` is `0` where there is no inset, so non-notched devices are unchanged.
- **Removed both bleed shadows** and #291's rule; corrected the comments that misattributed the cause.
- **Bonus fix (confirmed + reproduced):** the open-state `display:block` rules (0,3,1 / 1,1,1) out-ranked the markup's Tailwind `md:hidden` (0,1,0), so rotating a large phone to landscape with the drawer open left the drawer *and* the full-screen black overlay on screen, with the dismissing hamburger itself `md:hidden`. Added a guard that can't be out-specified.

## Verified

Real **WebKit** via Playwright (iPhone 13), not just Chromium:
- drawer spans `56 → 844`, `gap=0`, last nav row reachable after scrolling
- padding identical to pre-change at zero insets; grows correctly (47/47/47/46px) with simulated insets
- instant close (`display:none` in 4ms); overlay hidden when closed
- rotation guard: both elements hidden at ≥768px, restored on return
- a 6-scenario WebKit probe (toolbar expand/collapse, sticky-bar churn) showed `gap=0` in every case both before and after — confirming the layout engine was never the problem and this is iOS chrome behaviour

## Reviewer notes — please read

- **I could not test on real iOS here** (no Xcode/simulator on this machine, and Playwright's WebKit doesn't emulate iOS chrome or safe-area insets). This change is grounded in primary sources, but the last mile needs a device. Check in a **private tab**.
- **Honest caveat on causality:** the meta viewport has been missing `viewport-fit=cover` for the site's entire history — it is a *constant*, so it explains why the drawer stops short **today**, but not by itself why the bug appeared fixed after #289 and then returned. The most likely reading is that #289 removed the large mis-sizing and left a smaller structural undershoot that reads as "fixed" or "broken" depending on toolbar state. If you want certainty, the highest-value datum is your **exact iOS version** plus one measurement from the affected device (`innerHeight`, `documentElement.clientHeight`, `visualViewport.height`, `screen.height`, the drawer's `getBoundingClientRect().bottom`, and `env(safe-area-inset-bottom)` read through a custom property) — and OpenReplay is already recording those sessions.
- **Known risk:** [WebKit bug 301108](https://bugs.webkit.org/show_bug.cgi?id=301108) — *"REGRESSION (iOS 26): `<meta name=viewport>` does not work correctly for viewport-fit=cover or height=device-height"* — is still `NEW` and was last touched 2026-07-26. `viewport-fit=cover` is the correct opt-in, but it is not itself bug-free on iOS 26. If the band persists on-device after this, that bug is the first place to look, not the CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)