### PR TITLE
mobile: floating-card drawer — stop fighting for the iOS toolbar strip

### DIFF
--- a/public/redesign.css
+++ b/public/redesign.css
@@ -84,19 +84,32 @@ body {
 
 .or-footer-wrap { padding: 0 56px 40px; max-width: var(--or-content-max); margin-inline: auto; }
 
-/* mobile drawer */
+/* mobile drawer — a FLOATING CARD, not a full-bleed panel.
+   Why (the end of the #278–#296 saga): on iOS Safari a bottom-anchored fixed element
+   can only reach the LAYOUT-viewport bottom, which in the toolbar-expanded state sits
+   ~90–100pt above the physical screen bottom. Nothing author-side moves that edge:
+   viewport-fit=cover only removes SAFE-AREA insets (verified live on-device, PR #296 —
+   deployed and changed nothing), and painting past the viewport (lvh heights, shadow
+   bleeds, overflow) is clipped by WebKit on some iOS 26 builds and not others
+   (bugs.webkit.org 301108 still open). So the design stops needing that edge: the
+   drawer floats with a deliberate margin inside whatever viewport Safari provides,
+   and the strip below belongs to the overlay/scrim (see #mobile-overlay), which is
+   black under BOTH WebKit behaviors. Identical rendering in Chrome/Android/desktop. */
 .or-drawer {
 	background: var(--page);
-	/* Bottom/inline padding pays the safe-area tax now that the document is full-bleed
-	   (viewport-fit=cover in HeadCommon.astro): the drawer reaches the physical screen
-	   bottom, so the last nav row would otherwise sit under the home indicator and the
-	   floating iOS 26 toolbar. env() resolves to 0 where there is no inset (desktop,
-	   Android, portrait Safari tabs), so these collapse to the original values. */
-	padding-top: 14px;
-	padding-inline: max(12px, env(safe-area-inset-left, 0px)) max(12px, env(safe-area-inset-right, 0px));
-	padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 12px);
-	border-inline-end: 1px solid var(--or-border);
-	transform: translateX(-100%);
+	/* Geometry is owned HERE, not by Tailwind utilities in BaseLayout.astro — the
+	   utilities load after this file in production and silently win ties (PR #289's
+	   cascade trap). Logical inset-inline-start also fixes RTL: the card now anchors
+	   to the right edge on ar-ae pages, matching its slide-from-right transform. */
+	top: calc(var(--theme-navbar-height) + 10px);
+	bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+	inset-inline-start: max(10px, env(safe-area-inset-left, 0px));
+	border: 1px solid var(--or-border);
+	border-radius: 16px;
+	padding: 14px 12px 12px;
+	/* Closed-state transform must clear the inline inset AND the open-state shadow
+	   (60px blur), or a sliver stays visible at the screen edge. */
+	transform: translateX(calc(-100% - 90px));
 	/* `display:none` when closed removes the drawer from the layout entirely. A
 	   persistent full-viewport position:fixed element makes iOS Safari pin its layout
 	   viewport to the toolbar-hidden height and never revert — which leaves a stuck black
@@ -106,17 +119,9 @@ body {
 	/* Keep scroll momentum inside the drawer instead of chaining to the page behind
 	   it (which made it hard to scroll the menu back up on iOS). */
 	overscroll-behavior: contain;
-	/* Height comes from inset anchoring — the markup's `top-14 bottom-0` — and NOT from
-	   an explicit viewport-unit height. A vh/lvh/dvh height is wrong twice over: it
-	   overshoots the layout viewport (and WebKit CLIPS position:fixed to the inner
-	   viewport, so the overshoot is discarded, never painted behind the toolbar), and it
-	   puts the bottom slice of the drawer's OWN scrollport offscreen — a scroll container
-	   cannot reveal its own offscreen portion, so the last nav items become unreachable.
-	   Do NOT add height/min-height in vh/lvh/dvh units here.
-	   Inset anchoring only reaches the LAYOUT-viewport bottom, which on iOS 26 sits well
-	   above the physical screen bottom. Extending it is not a CSS job at all — it needs
-	   `viewport-fit=cover` on the meta viewport (see HeadCommon.astro). Without that opt-in
-	   the leftover strip is painted by Safari itself and reads as "the menu is cut short".
+	/* No explicit height — inset anchoring sizes the card. A vh/lvh/dvh height would put
+	   the bottom slice of the drawer's own scrollport offscreen (a scroll container
+	   cannot reveal its own offscreen portion → last nav items unreachable).
 	   The open/close transition lives on the open-state rule below (not here) so closing
 	   is INSTANT — otherwise the drawer lingers ~0.25s before display:none, keeping iOS's
 	   viewport pinned and flashing the gap back (the "weird half-second delay"). */
@@ -128,16 +133,12 @@ body {
 .or-left .lang-pill {
 	height: 38px;
 }
-[dir='rtl'] .or-drawer { transform: translateX(100%); }
-/* No "bleed" shadow here: a second `0 120px 0 0` shadow used to try to paint the drawer's
-   background into the strip below the layout viewport, but WebKit clips position:fixed
-   painting to the inner viewport (even with negative offsets), so it was a no-op on exactly
-   the iOS versions it was added for. viewport-fit=cover is what actually closes that strip. */
+[dir='rtl'] .or-drawer { transform: translateX(calc(100% + 90px)); }
 body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; transform: translateX(0); box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3); transition: transform 0.25s ease, display 0.25s allow-discrete; }
 /* Slide-in start state (for the display:none → block transition above). */
 @starting-style {
-	body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(-100%); }
-	[dir='rtl'] body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(100%); }
+	body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(calc(-100% - 90px)); }
+	[dir='rtl'] body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { transform: translateX(calc(100% + 90px)); }
 }
 /* touch-action:none stops a drag on the overlay from scrolling the page behind the
    drawer. On phones the document is the scroller, where `overflow:hidden` is an
@@ -145,10 +146,25 @@ body.mobile-sidebar-toggle #mobile-left-sidebar.or-drawer { display: block; tran
    keeps the background fixed. Taps still fire, so tap-to-close keeps working. */
 /* display:none when closed (same reason as the drawer above) — keep the overlay out of
    the layout so it can't pin iOS Safari's viewport once the menu has been used.
-   Sized by the markup's `inset-0` (inset anchoring, not viewport units) for the same
-   reason as the drawer above; never turn that into a height/min-height. Its bleed
-   box-shadow was removed too — see the note on the drawer's open-state rule. */
+   Sized by the markup's `inset-0` (inset anchoring, not viewport units — a vh/lvh
+   height risks clipping AND over-constrained cascade traps; see the drawer note). */
 #mobile-overlay { display: none; touch-action: none; }
+/* The strip BETWEEN the layout-viewport bottom and the physical screen bottom (iOS 26's
+   toolbar inset) must read as overlay-black so the floating drawer card sits on a
+   continuous scrim. This ::after paints 180px past the overlay's bottom edge. It is
+   correct under BOTH observed WebKit behaviors: where below-viewport painting is
+   allowed, the strip IS this pseudo-element; where WebKit clips it, Safari fills the
+   strip itself by sampling the edge-touching fixed element's background — this same
+   overlay, the same near-black. Do not "simplify" this into a height on the overlay. */
+#mobile-overlay::after {
+	content: '';
+	position: absolute;
+	top: 100%;
+	left: 0;
+	right: 0;
+	height: 180px;
+	background: rgb(0 0 0 / 0.9);
+}
 body.mobile-sidebar-toggle #mobile-overlay { display: block; }
 
 /* The open-state rules above (specificity 0,3,1 / 1,1,1) out-rank the markup's Tailwind

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -53,9 +53,12 @@ const breadcrumb = getBreadcrumb(currentPage);
 		<Header {currentPage} />
 
 		{/* Mobile Overlay Sidebar */}
+		{/* Geometry (insets) lives entirely in redesign.css .or-drawer — do not add
+		    top/bottom/left utilities here. Splitting geometry between Tailwind utilities
+		    and redesign.css caused repeated cascade traps (see PR #289/#296 history). */}
 		<aside
 			id="mobile-left-sidebar"
-			class="md:hidden fixed top-14 bottom-0 left-0 w-[300px] max-w-[85vw] overflow-y-auto z-50 or-noscroll or-drawer"
+			class="md:hidden fixed w-[300px] max-w-[85vw] overflow-y-auto z-50 or-noscroll or-drawer"
 		>
 			<LeftSidebar {currentPage} />
 		</aside>


### PR DESCRIPTION
## What the on-device test taught us

PR #296 (`viewport-fit=cover`) deployed cleanly and was verified live — and the drawer's bottom edge **did not move a pixel**. Measuring both screenshots puts that edge exactly at the layout-viewport bottom in the toolbar-expanded state (~645 of 844 CSS pt, top-address-bar layout), before and after.

That falsifies the safe-area theory and leaves a hard fact: **`viewport-fit=cover` removes safe-area insets, not the browser-toolbar inset.** No anchored fixed element can reach the physical screen bottom while Safari's toolbar is expanded — and painting past the viewport (lvh heights, shadow bleeds, overflow) is clipped on some iOS 26 builds and not others ([WebKit 301108](https://bugs.webkit.org/show_bug.cgi?id=301108), still open). The device is confirmed on iOS 26.1+, ruling out the fixed 26.0 clipping bug as well.

## The fix: stop needing the strip (design approved by @estradino)

The drawer becomes a **floating card** — 10px inline inset, 12px + safe-area bottom inset, 16px radius, full border, existing shadow. It matches iOS 26's floating-glass design language, and the same geometry that used to read as "cut short" now reads as intentional.

The strip below the layout viewport belongs to the **overlay**: a paint-only `::after` extends the black scrim 180px past its bottom edge. This is the key trick — it is correct under **both** observed WebKit behaviors:
- where below-viewport painting works → the strip *is* the pseudo-element (black);
- where WebKit clips it → Safari samples the edge-touching overlay's background for its own fill → the same near-black.

Either way: white card floating on continuous black. Identical in Safari, Chrome, Android, desktop — and robust to whatever iOS does to the viewport next.

Bonus fixes in passing:
- Drawer geometry now lives entirely in `redesign.css` (markup's `top-14 bottom-0 left-0` removed) — ends the Tailwind-vs-redesign cascade traps for good.
- `inset-inline-start` fixes RTL: on ar-ae pages the card now anchors to the **right** edge, matching its slide-from-right animation (previously it anchored left while animating from the right).

## Verified (real WebKit via Playwright, iPhone 13 emulation) — 12/12

card top/bottom/inline geometry · rounded corners + border · last nav row reachable after scrolling · overlay `::after` present and positioned below the viewport · instant close (3ms) · closed card fully off-screen including shadow blur · RTL right-anchoring (380/390 with 10px inset) · rotation guard (drawer+overlay hidden ≥768px) · dark-mode colors (dark card, subtle border).

## On-device check after deploy

Open the menu in Safari: you should see a rounded white card floating on black, with a deliberate black margin above the toolbar — no abrupt white cut-off. If any *non-black* band appears below the scrim, that's new information about WebKit's fill sampling and I want to know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)