### PR TITLE
Fix base URL format for self-hosted API (all locales)

### DIFF
--- a/src/pages/ar-ae/api.mdx
+++ b/src/pages/ar-ae/api.mdx
@@ -12,7 +12,7 @@ import LinkRow from '~/components/LinkRow.astro'
 استخدم عنوان URL الأساسي لواجهة برمجة التطبيقات العامة `v2` لجميع عمليات التكامل الجديدة. تُصادق جميع نقاط النهاية عبر مفتاح API الخاص بالمؤسسة. كل مسار مسبوق بـ `/public`.
 
 - Cloud Serverless: `https://api.openreplay.com/v2`
-- Cloud Dedicated / الاستضافة الذاتية: `https://YOUR_INSTANCE_DOMAIN/api/v2`
+- Cloud Dedicated / الاستضافة الذاتية: `https://YOUR_INSTANCE_DOMAIN/v2/api`
 
 في جميع أجزاء الوثائق أدناه، يشير `{BASE_URL}` إلى عنوان URL الأساسي المنطبق على عملية النشر الخاصة بك.
 

--- a/src/pages/es/api.mdx
+++ b/src/pages/es/api.mdx
@@ -12,7 +12,7 @@ La API de OpenReplay le permite gestionar datos de usuario y exportar eventos ca
 Utilice la URL base de la API pública `v2` para todas las integraciones nuevas. Todos los endpoints se autentican mediante la clave API de la organización. Cada ruta lleva el prefijo `/public`.
 
 - Cloud Serverless: `https://api.openreplay.com/v2`
-- Cloud Dedicated / autoalojado: `https://YOUR_INSTANCE_DOMAIN/api/v2`
+- Cloud Dedicated / autoalojado: `https://YOUR_INSTANCE_DOMAIN/v2/api`
 
 A lo largo de la documentación que aparece a continuación, `{BASE_URL}` hace referencia a la URL base que corresponda a su implementación.
 

--- a/src/pages/fr/api.mdx
+++ b/src/pages/fr/api.mdx
@@ -12,7 +12,7 @@ L'API OpenReplay vous permet de gérer les données utilisateur et d'exporter le
 Utilisez l'URL de base de l'API publique `v2` pour toutes les nouvelles intégrations. Tous les endpoints s'authentifient via la clé API de l'organisation. Chaque route est préfixée par `/public`.
 
 - Cloud Serverless : `https://api.openreplay.com/v2`
-- Cloud Dedicated / auto-hébergé : `https://YOUR_INSTANCE_DOMAIN/api/v2`
+- Cloud Dedicated / auto-hébergé : `https://YOUR_INSTANCE_DOMAIN/v2/api`
 
 Tout au long de la documentation ci-dessous, `{BASE_URL}` désigne l'URL de base qui correspond à votre déploiement.
 

--- a/src/pages/ru/api.mdx
+++ b/src/pages/ru/api.mdx
@@ -12,7 +12,7 @@ API OpenReplay позволяет управлять данными пользо
 Используйте базовый URL публичного API `v2` для всех новых интеграций. Все эндпоинты аутентифицируются с помощью API-ключа организации. Каждый маршрут имеет префикс `/public`.
 
 - Cloud Serverless: `https://api.openreplay.com/v2`
-- Cloud Dedicated / собственный хостинг: `https://YOUR_INSTANCE_DOMAIN/api/v2`
+- Cloud Dedicated / собственный хостинг: `https://YOUR_INSTANCE_DOMAIN/v2/api`
 
 В документации ниже `{BASE_URL}` обозначает тот базовый URL, который применим к вашему развёртыванию.
 

--- a/src/pages/zh/api.mdx
+++ b/src/pages/zh/api.mdx
@@ -12,7 +12,7 @@ OpenReplay API 允许您管理用户数据并导出捕获的事件以供外部�
 请在所有新集成中使用 `v2` 公共 API 基础 URL。所有端点均通过组织 API 密钥进行身份验证。每个路由都以 `/public` 为前缀。
 
 - Cloud Serverless：`https://api.openreplay.com/v2`
-- Cloud Dedicated / 自托管：`https://YOUR_INSTANCE_DOMAIN/api/v2`
+- Cloud Dedicated / 自托管：`https://YOUR_INSTANCE_DOMAIN/v2/api`
 
 在下文的整个文档中，`{BASE_URL}` 指代适用于您部署环境的相应基础 URL。
 


### PR DESCRIPTION
Ports [0ed3b28a](https://github.com/openreplay/documentation/commit/0ed3b28a97e3c41a1317b97f8d575fbe133ee7a9) ("Fix base URL format for self-hosted API") to the five translated locales, which still carried the incorrect URL.

## What changed

One line in each of `src/pages/{es,fr,ru,zh,ar-ae}/api.mdx` (line 15), under **Base URL (v2 - Current)**:

```diff
- https://YOUR_INSTANCE_DOMAIN/api/v2
+ https://YOUR_INSTANCE_DOMAIN/v2/api
```

## Why

The original fix landed on `src/pages/en/api.mdx` only, so non-English readers on Cloud Dedicated / self-hosted were still being given a base URL that doesn't resolve. This brings all locales in line with EN.

## Notes for the reviewer

- **Translated labels are untouched.** The change is a pure ASCII substring swap on the URL, so each locale keeps its own wording and punctuation — French `/ auto-hébergé :`, Chinese `：`, and the Arabic RTL text all render exactly as before.
- **Versioned folders are intentionally excluded.** `v1.25.0` and `v1.26.0` do mention `YOUR_INSTANCE_DOMAIN`, but as `https://YOUR_INSTANCE_DOMAIN/api/` — the *v1* API base URL, which this fix does not affect. EN's own versioned copies were likewise untouched by the original commit, so editing them here would introduce drift rather than remove it. Older version folders have no v2 section at all.
- **No stale occurrences remain:** a repo-wide grep for `YOUR_INSTANCE_DOMAIN/api/v2` now returns nothing.

Diff is 5 files, +5/-5, text-only — no build or config surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)